### PR TITLE
feat: Artistの重複チェックをソフトデリート対応にし、show APIを追加

### DIFF
--- a/app/Http/Controllers/Api/ArtistController.php
+++ b/app/Http/Controllers/Api/ArtistController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Artist;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 
 class ArtistController extends Controller
 {
@@ -35,9 +36,15 @@ class ArtistController extends Controller
     {
         Gate::authorize('create', Artist::class);
 
+        // 削除済み（ソフトデリート）データは重複チェックから除外
         $data = $request->validate([
-            'name' => 'required|string|max:100|unique:artists,name',
-            'kana' => 'required|string|max:100'
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                Rule::unique('artists', 'name')->whereNull('deleted_at'),
+            ],
+            'kana' => 'required|string|max:100',
         ]);
 
         Artist::create($data);
@@ -47,17 +54,34 @@ class ArtistController extends Controller
         ], 201);
     }
 
+    public function show(Artist $artist)
+    {
+        Gate::authorize('view', $artist);
+
+        return response()->json([
+            'artist' => $artist,
+        ]);
+    }
+
     public function update(Request $request, Artist $artist)
     {
         Gate::authorize('update', $artist);
 
+        // 自分自身と削除済み（ソフトデリート）データは重複チェックから除外
         $data = $request->validate([
-            'name' => 'required|string|max:100|unique:artists,name,' . $artist->id, // このidのデータは除く
-            'kana' => 'required|string|max:100'
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                Rule::unique('artists', 'name')
+                    ->ignore($artist->id)
+                    ->whereNull('deleted_at'),
+            ],
+            'kana' => 'required|string|max:100',
         ]);
 
         $artist->update($data);
-        
+
         return response()->json([
             'message' => 'Artist updated successfully',
         ]);
@@ -68,10 +92,9 @@ class ArtistController extends Controller
         Gate::authorize('delete', $artist);
 
         $artist->delete();
-        
+
         return response()->json([
             'message' => 'Artist deleted successfully'
         ]);
     }
-
 }

--- a/database/migrations/2026_07_30_000000_drop_unique_name_from_artists_table.php
+++ b/database/migrations/2026_07_30_000000_drop_unique_name_from_artists_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->dropUnique(['name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->unique('name');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,7 +79,7 @@ Route::prefix('notifications')->middleware('auth:sanctum')->group(function () {
 });
 
 Route::middleware(['auth:sanctum', 'can:access-admin'])->prefix('admin')->group(function () {
-    Route::apiResource('artists', ArtistController::class)->except(['show']);
+    Route::apiResource('artists', ArtistController::class);
     // 他に管理者限定のものがあればここへ
 });
 


### PR DESCRIPTION
- name のユニークバリデーションを削除済み(soft delete)データを除外する形に変更し、DB側のunique制約も削除
- 管理者用APIにアーティスト詳細取得(show)エンドポイントを追加