### PR TITLE
developをmainにマージ: API移行(Sanctumトークン認証)対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+/docs/notes

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Homestead.json
 Homestead.yaml
 Thumbs.db
 /docs/notes
+CLAUDE.md
+.claude/

--- a/app/Console/Commands/CleanupOrphanedLikes.php
+++ b/app/Console/Commands/CleanupOrphanedLikes.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class CleanupOrphanedLikes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'likes:cleanup-orphans {--dry : ドライラン（削除しない、対象件数のみ表示）}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '参照先のDiary/Commentが既に存在しないlikesレコード（孤児データ）を削除する';
+
+    public function handle(): int
+    {
+        $dry = (bool)$this->option('dry');
+
+        $targets = [
+            \App\Models\Diary::class => 'diaries',
+            \App\Models\Comment::class => 'comments',
+        ];
+
+        $totalToDelete = 0;
+
+        foreach ($targets as $likeableType => $parentTable) {
+            $query = DB::table('likes')
+                ->where('likeable_type', $likeableType)
+                ->whereNotIn('likeable_id', DB::table($parentTable)->select('id'));
+
+            $count = (clone $query)->count();
+            $totalToDelete += $count;
+
+            $this->info("[{$likeableType}] 孤児いいね: {$count} 件");
+
+            if ($dry && $count > 0) {
+                $sample = (clone $query)->limit(5)->get(['id', 'user_id', 'likeable_id', 'created_at']);
+                $this->line('---サンプル(先頭5件)---');
+                $this->line(print_r($sample->toArray(), true));
+            }
+        }
+
+        if ($totalToDelete === 0) {
+            $this->info('孤児いいねは0件でした。削除不要です。');
+            return self::SUCCESS;
+        }
+
+        if ($dry) {
+            $this->warn("ドライランのため削除は行いません。合計 {$totalToDelete} 件が削除対象です。");
+            return self::SUCCESS;
+        }
+
+        DB::beginTransaction();
+        try {
+            $deleted = 0;
+            foreach ($targets as $likeableType => $parentTable) {
+                $deleted += DB::table('likes')
+                    ->where('likeable_type', $likeableType)
+                    ->whereNotIn('likeable_id', DB::table($parentTable)->select('id'))
+                    ->delete();
+            }
+            DB::commit();
+            $this->info("削除完了: {$deleted} 件");
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            $this->error('削除に失敗: '.$e->getMessage());
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/AiDiaryController.php
+++ b/app/Http/Controllers/Api/AiDiaryController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\GeminiClient;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class AiDiaryController extends Controller
+{
+    public function suggest(Request $request, GeminiClient $gemini)
+    {
+        $data = $request->validate([
+            'prompt' => 'required|string|max:2000',
+            'interaction_id' => 'nullable|string'
+        ]);
+
+        try {
+            $result = $gemini->generate($data['interaction_id'] ?? null, $data['prompt']);
+
+            return response()->json([
+                'ok' => true,
+                'reply' => $result['text'],
+                'interaction_id' => $result['interaction_id']
+            ], 200);
+
+        } catch (\Throwable $e) {
+            Log::warning('AI suggest failed', ['error' => $e->getMessage()]);
+            return response()->json([
+                'ok' => false,
+                'message' => 'AI処理に失敗しました。短い入力で再実行してください。'
+            ], 422);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/AiDiaryController.php
+++ b/app/Http/Controllers/Api/AiDiaryController.php
@@ -12,8 +12,8 @@ class AiDiaryController extends Controller
     public function suggest(Request $request, GeminiClient $gemini)
     {
         $data = $request->validate([
-            'prompt' => 'required|string|max:2000',
-            'interaction_id' => 'nullable|string'
+            'interaction_id' => 'nullable|string',
+            'prompt' => 'required|string|max:2000'
         ]);
 
         try {
@@ -24,7 +24,6 @@ class AiDiaryController extends Controller
                 'reply' => $result['text'],
                 'interaction_id' => $result['interaction_id']
             ], 200);
-
         } catch (\Throwable $e) {
             Log::warning('AI suggest failed', ['error' => $e->getMessage()]);
             return response()->json([

--- a/app/Http/Controllers/Api/ArtistController.php
+++ b/app/Http/Controllers/Api/ArtistController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Artist;
+use Illuminate\Http\Request;
+
+class ArtistController extends Controller
+{
+    public function search(Request $request)
+    {
+        $artists = Artist::where('name', 'LIKE', "%{$request->q}%")
+            ->orWhere('kana', 'LIKE', "%{$request->q}%")
+            ->orderBy('name')
+            ->limit(20)
+            ->get(['id', 'name']);
+        
+        return response()->json($artists);
+    }
+}

--- a/app/Http/Controllers/Api/ArtistController.php
+++ b/app/Http/Controllers/Api/ArtistController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Artist;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class ArtistController extends Controller
 {
@@ -15,7 +16,62 @@ class ArtistController extends Controller
             ->orderBy('name')
             ->limit(20)
             ->get(['id', 'name']);
-        
+
         return response()->json($artists);
     }
+
+    public function index()
+    {
+        Gate::authorize('viewAny', Artist::class);
+
+        $artists = Artist::orderBy('kana')->paginate(20);
+
+        return response()->json([
+            "artists" => $artists,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        Gate::authorize('create', Artist::class);
+
+        $data = $request->validate([
+            'name' => 'required|string|max:100|unique:artists,name',
+            'kana' => 'required|string|max:100'
+        ]);
+
+        Artist::create($data);
+
+        return response()->json([
+            'message' => 'Artist created successfully'
+        ], 201);
+    }
+
+    public function update(Request $request, Artist $artist)
+    {
+        Gate::authorize('update', $artist);
+
+        $data = $request->validate([
+            'name' => 'required|string|max:100|unique:artists,name,' . $artist->id, // このidのデータは除く
+            'kana' => 'required|string|max:100'
+        ]);
+
+        $artist->update($data);
+        
+        return response()->json([
+            'message' => 'Artist updated successfully',
+        ]);
+    }
+
+    public function destroy(Artist $artist)
+    {
+        Gate::authorize('delete', $artist);
+
+        $artist->delete();
+        
+        return response()->json([
+            'message' => 'Artist deleted successfully'
+        ]);
+    }
+
 }

--- a/app/Http/Controllers/Api/ArtistController.php
+++ b/app/Http/Controllers/Api/ArtistController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Artist;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 
 class ArtistController extends Controller
 {
@@ -35,9 +36,15 @@ class ArtistController extends Controller
     {
         Gate::authorize('create', Artist::class);
 
+        // 削除済み（ソフトデリート）データは重複チェックから除外
         $data = $request->validate([
-            'name' => 'required|string|max:100|unique:artists,name',
-            'kana' => 'required|string|max:100'
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                Rule::unique('artists', 'name')->whereNull('deleted_at'),
+            ],
+            'kana' => 'required|string|max:100',
         ]);
 
         Artist::create($data);
@@ -47,17 +54,34 @@ class ArtistController extends Controller
         ], 201);
     }
 
+    public function show(Artist $artist)
+    {
+        Gate::authorize('view', $artist);
+
+        return response()->json([
+            'artist' => $artist,
+        ]);
+    }
+
     public function update(Request $request, Artist $artist)
     {
         Gate::authorize('update', $artist);
 
+        // 自分自身と削除済み（ソフトデリート）データは重複チェックから除外
         $data = $request->validate([
-            'name' => 'required|string|max:100|unique:artists,name,' . $artist->id, // このidのデータは除く
-            'kana' => 'required|string|max:100'
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                Rule::unique('artists', 'name')
+                    ->ignore($artist->id)
+                    ->whereNull('deleted_at'),
+            ],
+            'kana' => 'required|string|max:100',
         ]);
 
         $artist->update($data);
-        
+
         return response()->json([
             'message' => 'Artist updated successfully',
         ]);
@@ -68,10 +92,9 @@ class ArtistController extends Controller
         Gate::authorize('delete', $artist);
 
         $artist->delete();
-        
+
         return response()->json([
             'message' => 'Artist deleted successfully'
         ]);
     }
-
 }

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules;
+
+
+class AuthController extends Controller
+{
+    public function register(Request $request)
+    {
+        $validatedData = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'unique:' . User::class],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        $user = User::create([
+            'name' => $validatedData['name'],
+            'email' => $validatedData['email'],
+            'password' => Hash::make($validatedData['password']),
+        ]);
+
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        return response()->json([
+            'access_token' => $token,
+            'token_type' => 'Bearer',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -7,7 +7,8 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
-
+// use Auth;
+use Illuminate\Support\Facades\Auth;
 
 class AuthController extends Controller
 {
@@ -16,20 +17,66 @@ class AuthController extends Controller
         $validatedData = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'unique:' . User::class],
+            // Password::defaults() でアプリ全体のパスワードポリシー（最低文字数・記号など）を一括適用する
+            // ポリシーの変更は AppServiceProvider::boot() で行うことで全エンドポイントに自動反映される
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
         $user = User::create([
             'name' => $validatedData['name'],
             'email' => $validatedData['email'],
+            // パスワードは必ずハッシュ化して保存する（平文保存はセキュリティ上許容されない）
             'password' => Hash::make($validatedData['password']),
         ]);
+
+        // plainTextToken はトークン生成時にのみ取得可能で、DB にはハッシュ値のみ保存される
+        // このレスポンス以降は再取得できないため、クライアントは必ず安全な場所に保存する必要がある
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        return response()->json([
+            'access_token' => $token,
+            'token_type' => 'Bearer',
+        ]);
+    }
+
+    public function login(Request $request)
+    {
+        $request->validate([
+            'email' => ['required', 'email'],
+            // ログインは既存ハッシュとの照合のみのため、パスワード強度チェックは不要
+            'password' => ['required'],
+        ]);
+
+        // only() で email と password だけを抽出し、余分なフィールドが Auth::attempt に渡らないようにする
+        $credentials = $request->only('email', 'password');
+
+        // Auth::attempt はDBを検索してパスワードのハッシュ照合まで自動で行う
+        // このAPIはSanctumによるトークン認証（ステートレス）のため、セッションは使用しない
+        if (!Auth::attempt($credentials)) {
+            return response()->json([
+                'message' => 'Invalid login details'
+            ], 401);
+        }
+
+        // Auth::attempt はユーザーモデルを返さないため、トークン発行のために別途取得する
+        // attempt 成功時点でメールアドレスの存在は確定しているので firstOrFail で取得する
+        $user = User::where('email', $request['email'])->firstOrFail();
 
         $token = $user->createToken('auth_token')->plainTextToken;
 
         return response()->json([
             'access_token' => $token,
             'token_type' => 'Bearer',
+        ]);
+    }
+
+    public function logout(Request $request) {
+        // currentAccessToken() で現在のリクエストに使用されたトークンのみを削除する
+        // user()->tokens()->delete() とは異なり、他デバイスのセッションには影響しない
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json([
+            'message' => 'Successfully logged out'
         ]);
     }
 }

--- a/app/Http/Controllers/Api/CommentController.php
+++ b/app/Http/Controllers/Api/CommentController.php
@@ -18,7 +18,7 @@ class CommentController extends Controller
             return abort(403);
         }
 
-        $validated = $request->validateWithBag('comment', [
+        $validated = $request->validate([
             'body' => ['required', 'string', 'max:2000'],
         ]);
 
@@ -42,7 +42,7 @@ class CommentController extends Controller
             return abort(403);
         }
 
-        $validated = $request->validateWithBag('reply', [
+        $validated = $request->validate([
             'body' => ['required', 'string', 'max:2000'],
             // exists:comments,id コメントテーブルのidに存在する
             'parent_id' => ['required', 'integer', 'exists:comments,id'],

--- a/app/Http/Controllers/Api/CommentController.php
+++ b/app/Http/Controllers/Api/CommentController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Comment;
+use App\Models\Diary;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+class CommentController extends Controller
+{
+    public function store(Request $request, Diary $diary)
+    {
+        Gate::authorize('create', Comment::class);
+
+        if (!$diary->is_public && auth()->id() !== $diary->user_id) {
+            return abort(403);
+        }
+
+        $validated = $request->validateWithBag('comment', [
+            'body' => ['required', 'string', 'max:2000'],
+        ]);
+
+        $diary->comments()->create([
+            'user_id' => auth()->id(),
+            'body' => $validated['body'],
+            'parent_id' => null,
+        ]);
+
+        return response()->json([
+            'message' => 'Comment created successfully'
+        ], 201);
+
+    }
+
+    public function reply(Request $request, Diary $diary)
+    {
+        Gate::authorize('reply', Comment::class);
+
+        if (!$diary->is_public && auth()->id() !== $diary->user_id) {
+            return abort(403);
+        }
+
+        $validated = $request->validateWithBag('reply', [
+            'body' => ['required', 'string', 'max:2000'],
+            // exists:comments,id コメントテーブルのidに存在する
+            'parent_id' => ['required', 'integer', 'exists:comments,id'],
+        ]);
+
+        $parent = Comment::findOrFail($validated['parent_id']);
+        if ($parent->diary_id !== $diary->id) {
+            abort(422, '親コメントがこの日記のものではありません。');
+        }
+
+        $diary->comments()->create([
+            'user_id' => $request->user()->id,
+            'body' => $validated['body'],
+            'parent_id' => $validated['parent_id'],
+        ]);
+
+        return response()->json([
+            'message' => 'Reply comment created successfully'
+        ], 201);
+    }
+
+    public function destroy(Comment $comment)
+    {
+        Gate::authorize('delete', $comment);
+
+        $isReply = $comment->parent_id !== null;
+
+        $comment->delete();
+
+        return response()->json([
+            'isReply' => $isReply,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/CommentController.php
+++ b/app/Http/Controllers/Api/CommentController.php
@@ -14,9 +14,7 @@ class CommentController extends Controller
     {
         Gate::authorize('create', Comment::class);
 
-        if (!$diary->is_public && auth()->id() !== $diary->user_id) {
-            return abort(403);
-        }
+        abort_unless($diary->isVisibleOrOwnedBy($request->user()), 403);
 
         $validated = $request->validate([
             'body' => ['required', 'string', 'max:2000'],
@@ -38,9 +36,7 @@ class CommentController extends Controller
     {
         Gate::authorize('reply', Comment::class);
 
-        if (!$diary->is_public && auth()->id() !== $diary->user_id) {
-            return abort(403);
-        }
+        abort_unless($diary->isVisibleOrOwnedBy($request->user()), 403);
 
         $validated = $request->validate([
             'body' => ['required', 'string', 'max:2000'],

--- a/app/Http/Controllers/Api/CommentLikeController.php
+++ b/app/Http/Controllers/Api/CommentLikeController.php
@@ -10,6 +10,8 @@ class CommentLikeController extends Controller
 {
     public function store(Request $request, Comment $comment)
     {
+        abort_unless($comment->isVisibleTo($request->user()), 403);
+
         $like = $comment->likes()->firstOrCreate([
             'user_id' => $request->user()->id,
         ]);
@@ -23,6 +25,8 @@ class CommentLikeController extends Controller
 
     public function destroy(Request $request, Comment $comment)
     {
+        abort_unless($comment->isVisibleTo($request->user()), 403);
+
         $like = $comment->likes()->where('user_id', $request->user()->id)->first();
         if ($like) {
             $like->delete();

--- a/app/Http/Controllers/Api/CommentLikeController.php
+++ b/app/Http/Controllers/Api/CommentLikeController.php
@@ -39,8 +39,11 @@ class CommentLikeController extends Controller
         ]);
     }
 
-    public function commentLikers(Comment $comment)
+    public function commentLikers(Request $request, Comment $comment)
     {
+        // コメントオーナーとログインユーザーが別なら403を返す
+        // コメントオーナーしかいいねしたユーザーを見られない
+        abort_unless($comment->user_id === $request->user()->id, 403);
         $likers = $comment->likers()
             ->orderByPivot('created_at', 'desc')
             ->paginate(10)
@@ -48,7 +51,6 @@ class CommentLikeController extends Controller
 
         $comment->load('diary.user');
 
-        // return view('comments.likes.index', compact('comment', 'likers'));
         return response()->json([
             'comment' => $comment,
             'likers' => $likers,

--- a/app/Http/Controllers/Api/CommentLikeController.php
+++ b/app/Http/Controllers/Api/CommentLikeController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Comment;
+use Illuminate\Http\Request;
+
+class CommentLikeController extends Controller
+{
+    public function store(Request $request, Comment $comment)
+    {
+        $like = $comment->likes()->firstOrCreate([
+            'user_id' => $request->user()->id,
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'liked' => true,
+            'count' => $comment->likes()->count(),
+        ], 201);
+    }
+
+    public function destroy(Request $request, Comment $comment)
+    {
+        $like = $comment->likes()->where('user_id', $request->user()->id)->first();
+        if ($like) {
+            $like->delete();
+        }
+
+        return response()->json([
+            'ok' => true,
+            'liked' => false,
+            'count' => $comment->likes()->count(),
+        ]);
+    }
+
+    public function commentLikers(Comment $comment)
+    {
+        $likers = $comment->likers()
+            ->orderByPivot('created_at', 'desc')
+            ->paginate(10)
+            ->withQueryString();
+
+        $comment->load('diary.user');
+
+        // return view('comments.likes.index', compact('comment', 'likers'));
+        return response()->json([
+            'comment' => $comment,
+            'likers' => $likers,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/DiaryController.php
+++ b/app/Http/Controllers/Api/DiaryController.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Artist;
+use App\Models\Comment;
+use App\Models\Diary;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+class DiaryController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        $year = $request->integer('year');
+        $artist = $request->integer('artist');
+
+        $diaries = $user->diaries()
+            ->with(['artist', 'coverImage'])
+            // when:$yearがあれば、関数を実行。if($year)と同じ
+            ->when($year, fn($q) => $q->whereYear('happened_on', $year))
+            ->when($artist, fn($q) => $q->where('artist_id', $artist))
+            ->withCount(['comments', 'likes']) // コメント数、いいね数
+            ->withExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())])
+            ->orderBy('happened_on', 'desc') // まず日付の新しい順
+            ->orderBy('updated_at', 'desc') // 同じ日付の中で更新の新しい順
+            ->paginate(6) // ページネーション付きで取得
+            ->withQueryString(); // 次のページにも検索条件を引き継ぐ
+
+        $minDate = Diary::min('happened_on');
+        // 日付を扱う時はCarbonが便利
+        $minYear = $minDate ? Carbon::parse($minDate)->year : 2021;
+        $years = range(now()->year, $minYear);
+        // artist_tableからidがdiaries.artist_idに一致するものに絞り込む
+        $artists = Artist::whereIn('id', function ($q)  use ($user) {
+            $q->select('artist_id')
+                ->from('diaries') // diariesからartist_idの一覧を取り出す
+                ->where('user_id', $user->id) // そのユーザーが書いた日記に限定
+                ->whereNotNull('artist_id');
+        })->orderBy('name')
+            ->get(['id', 'name']);
+
+        return response()->json([
+            'diaries' => $diaries,
+            'years' => $years,
+            'artists' => $artists,
+            'year' => $year,
+            'artist' => $artist,
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'happened_on' => ['required', 'date'],
+            // exists:artists,id→存在しないartist_idが入らないようにする
+            'artist_id' => ['required', 'integer', 'exists:artists,id'],
+            'body' => ['required', 'string'],
+            'images' => ['nullable', 'array'],
+            // images.*とすることで,複数ファイル（配列）をチェック可能
+            // image:画像かどうか、mimes:許可する拡張子、max:5120 5MB
+            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:5120'],
+            'is_public' => ['boolean']
+        ]);
+
+        $diary = $request->user()->diaries()->create([
+            'happened_on' => $validated['happened_on'],
+            'artist_id' => $validated['artist_id'],
+            'body' => $validated['body'],
+            'is_public' => $validated['is_public'] ?? false,
+        ]);
+
+        if ($request->hasFile('images')) {
+            foreach ($request->file('images') as $imageFile) {
+                $ext = strtolower($imageFile->getClientOriginalExtension());
+                $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
+                $path = $imageFile->storeAs('diary_images', $filename, 'public');
+                // storage/app/public/diary_imagesに保存
+                // storeは毎回ユニークなファイル名（ハッシュ由来+拡張子）を自動生成
+                $diary->images()->create(['path' => $path]);
+            }
+        }
+
+        return response()->json([
+            'diary' => $diary,
+        ], 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Diary $diary)
+    {
+        Gate::authorize('view', $diary);
+
+        $diary->load(['user'])
+            ->loadCount(['comments', 'likes'])
+            ->loadExists([
+                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
+            ]);
+
+        // コメントをlikes_count / liked_by_me 付きで取得
+        // コメントへの返信を多層化：親コメントは新着順、返信コメントは古い順にソート
+        // 親を除く全ての返信数をカウント
+        $comments = Comment::query()
+            ->leftJoin('comments as r', 'r.id', '=', 'comments.root_id')
+            ->where('comments.diary_id', $diary->id)
+            ->orderByDesc('r.created_at')
+            ->orderBy('comments.path')
+            ->select('comments.*')
+            ->with('user')
+            ->withCount(['replies', 'likes'])
+            ->withExists([
+                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
+            ])
+            ->get();
+
+        // return view('diaries.show', compact('diary', 'comments'));
+        return response()->json([
+            'diary' => $diary,
+            'comments' => $comments,
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Diary $diary)
+    {
+        Gate::authorize('update', $diary);
+
+        $validated = $request->validate([
+            'happened_on' => ['required', 'date'],
+            // exists:artists,id→存在しないartist_idが入らないようにする
+            'artist_id' => ['required', 'integer', 'exists:artists,id'],
+            'body' => ['required', 'string'],
+            'images' => ['nullable','array'],
+            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:5120'],
+            'is_public' => ['boolean'],
+            'delete_images' => ['nullable', 'array'],
+            'delete_images.*' => ['integer', 'distinct', 'exists:diary_images,id'],
+        ]);
+
+        $diary->update([
+            'happened_on' => $validated['happened_on'],
+            'artist_id' => $validated['artist_id'],
+            'body' => $validated['body'],
+            'is_public' => $validated['is_public'],
+        ]);
+
+        // 画像の物理削除とDBの削除
+        $deleteIds = $request->input('delete_images', []);
+        if (!empty($deleteIds)) {
+            $images = $diary->images()->whereIn('id', $deleteIds)->get();
+            foreach ($images as $image) {
+                Storage::disk('public')->delete($image->path);
+                $image->delete();
+            }
+        }
+
+        if ($request->hasFile('images')) {
+            foreach ($request->file('images') as $imageFile) {
+                $ext = strtolower($imageFile->getClientOriginalExtension());
+                $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
+                $path = $imageFile->storeAs('diary_images', $filename, 'public');
+                // storage/app/public/diary_imagesに保存
+                // storeは毎回ユニークなファイル名（ハッシュ由来+拡張子）を自動生成
+                $diary->images()->create(['path' => $path]);
+            }
+        }
+
+        return response()->json([
+            'diary' => $diary,
+        ]);
+
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Diary $diary)
+    {
+        Gate::authorize('delete', $diary);
+
+        // 画像のパスだけを取り出す。all()は中身を素の配列に変換
+        $paths = $diary->images()->pluck('path')->all();
+        // 親を削除、画像はCASCADEで自動削除     
+        $diary->delete();
+
+        try {
+            Storage::disk('public')->delete($paths); // ファイルの物理削除
+        } catch (Throwable $e) { // 何かしらのエラーが起きた時だけ実行、例外＆エラーを開発車向けに表示
+            Log::warning('Failed deleting diary image files', [
+                'paths' => $paths,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return response()->noContent(); // ボディなし
+    }
+}

--- a/app/Http/Controllers/Api/DiaryController.php
+++ b/app/Http/Controllers/Api/DiaryController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Artist;
 use App\Models\Comment;
 use App\Models\Diary;
+use App\Services\DiaryService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Gate;
@@ -15,40 +16,29 @@ use Throwable;
 
 class DiaryController extends Controller
 {
+    // オブジェクトが持つ変数（プロパティ）として宣言。他のメソッドから $this->diaryService で使える
+    protected $diaryService;
+
+    // コンストラクタ：クラスのインスタンス生成時に自動で呼ばれる
+    // 引数に型（DiaryService）を書くだけで、Laravelが自動で new DiaryService() して渡してくれる（依存性注入）
+    public function __construct(DiaryService $diaryService)
+    {
+        // 引数で受け取った $diaryService をプロパティに保存する
+        // $this = このオブジェクト自身を指す特別な変数
+        $this->diaryService = $diaryService;
+    }
     /**
      * Display a listing of the resource.
      */
     public function index(Request $request)
     {
-        $user = $request->user();
-
-        $year = $request->integer('year');
-        $artist = $request->integer('artist');
-
-        $diaries = $user->diaries()
-            ->with(['artist', 'coverImage'])
-            // when:$yearがあれば、関数を実行。if($year)と同じ
-            ->when($year, fn($q) => $q->whereYear('happened_on', $year))
-            ->when($artist, fn($q) => $q->where('artist_id', $artist))
-            ->withCount(['comments', 'likes']) // コメント数、いいね数
-            ->withExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())])
-            ->orderBy('happened_on', 'desc') // まず日付の新しい順
-            ->orderBy('updated_at', 'desc') // 同じ日付の中で更新の新しい順
-            ->paginate(6) // ページネーション付きで取得
-            ->withQueryString(); // 次のページにも検索条件を引き継ぐ
-
-        $minDate = Diary::min('happened_on');
-        // 日付を扱う時はCarbonが便利
-        $minYear = $minDate ? Carbon::parse($minDate)->year : 2021;
-        $years = range(now()->year, $minYear);
-        // artist_tableからidがdiaries.artist_idに一致するものに絞り込む
-        $artists = Artist::whereIn('id', function ($q)  use ($user) {
-            $q->select('artist_id')
-                ->from('diaries') // diariesからartist_idの一覧を取り出す
-                ->where('user_id', $user->id) // そのユーザーが書いた日記に限定
-                ->whereNotNull('artist_id');
-        })->orderBy('name')
-            ->get(['id', 'name']);
+        [
+            'diaries' => $diaries,
+            'years' => $years,
+            'artists' => $artists,
+            'year' => $year,
+            'artist' => $artist,
+        ] = $this->diaryService->allDiaries($request);
 
         return response()->json([
             'diaries' => $diaries,
@@ -147,7 +137,7 @@ class DiaryController extends Controller
             // exists:artists,id→存在しないartist_idが入らないようにする
             'artist_id' => ['required', 'integer', 'exists:artists,id'],
             'body' => ['required', 'string'],
-            'images' => ['nullable','array'],
+            'images' => ['nullable', 'array'],
             'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:5120'],
             'is_public' => ['boolean'],
             'delete_images' => ['nullable', 'array'],
@@ -185,7 +175,6 @@ class DiaryController extends Controller
         return response()->json([
             'diary' => $diary,
         ]);
-
     }
 
     /**

--- a/app/Http/Controllers/Api/DiaryController.php
+++ b/app/Http/Controllers/Api/DiaryController.php
@@ -3,16 +3,12 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Artist;
-use App\Models\Comment;
+use App\Http\Requests\StoreDiaryRequest;
+use App\Http\Requests\UpdateDiaryRequest;
 use App\Models\Diary;
 use App\Services\DiaryService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
-use Throwable;
 
 class DiaryController extends Controller
 {
@@ -52,36 +48,13 @@ class DiaryController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreDiaryRequest $request)
     {
-        $validated = $request->validate([
-            'happened_on' => ['required', 'date'],
-            // exists:artists,id→存在しないartist_idが入らないようにする
-            'artist_id' => ['required', 'integer', 'exists:artists,id'],
-            'body' => ['required', 'string'],
-            'images' => ['nullable', 'array'],
-            // images.*とすることで,複数ファイル（配列）をチェック可能
-            // image:画像かどうか、mimes:許可する拡張子、max:5120 5MB
-            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:5120'],
-            'is_public' => ['boolean']
-        ]);
 
-        $diary = $request->user()->diaries()->create([
-            'happened_on' => $validated['happened_on'],
-            'artist_id' => $validated['artist_id'],
-            'body' => $validated['body'],
-            'is_public' => $validated['is_public'] ?? false,
-        ]);
+        $diary = $this->diaryService->createDiary($request);
 
         if ($request->hasFile('images')) {
-            foreach ($request->file('images') as $imageFile) {
-                $ext = strtolower($imageFile->getClientOriginalExtension());
-                $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
-                $path = $imageFile->storeAs('diary_images', $filename, 'public');
-                // storage/app/public/diary_imagesに保存
-                // storeは毎回ユニークなファイル名（ハッシュ由来+拡張子）を自動生成
-                $diary->images()->create(['path' => $path]);
-            }
+            $this->diaryService->attachImages($diary, $request->file('images'));
         }
 
         return response()->json([
@@ -96,29 +69,11 @@ class DiaryController extends Controller
     {
         Gate::authorize('view', $diary);
 
-        $diary->load(['user'])
-            ->loadCount(['comments', 'likes'])
-            ->loadExists([
-                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
-            ]);
+        [
+            'diary' => $diary,
+            'comments' => $comments,
+        ] = $this->diaryService->showDiary($diary);
 
-        // コメントをlikes_count / liked_by_me 付きで取得
-        // コメントへの返信を多層化：親コメントは新着順、返信コメントは古い順にソート
-        // 親を除く全ての返信数をカウント
-        $comments = Comment::query()
-            ->leftJoin('comments as r', 'r.id', '=', 'comments.root_id')
-            ->where('comments.diary_id', $diary->id)
-            ->orderByDesc('r.created_at')
-            ->orderBy('comments.path')
-            ->select('comments.*')
-            ->with('user')
-            ->withCount(['replies', 'likes'])
-            ->withExists([
-                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
-            ])
-            ->get();
-
-        // return view('diaries.show', compact('diary', 'comments'));
         return response()->json([
             'diary' => $diary,
             'comments' => $comments,
@@ -128,48 +83,17 @@ class DiaryController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Diary $diary)
+    public function update(UpdateDiaryRequest $request, Diary $diary)
     {
         Gate::authorize('update', $diary);
 
-        $validated = $request->validate([
-            'happened_on' => ['required', 'date'],
-            // exists:artists,id→存在しないartist_idが入らないようにする
-            'artist_id' => ['required', 'integer', 'exists:artists,id'],
-            'body' => ['required', 'string'],
-            'images' => ['nullable', 'array'],
-            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:5120'],
-            'is_public' => ['boolean'],
-            'delete_images' => ['nullable', 'array'],
-            'delete_images.*' => ['integer', 'distinct', 'exists:diary_images,id'],
-        ]);
+        $this->diaryService->updateDiary($request, $diary);
 
-        $diary->update([
-            'happened_on' => $validated['happened_on'],
-            'artist_id' => $validated['artist_id'],
-            'body' => $validated['body'],
-            'is_public' => $validated['is_public'],
-        ]);
-
-        // 画像の物理削除とDBの削除
-        $deleteIds = $request->input('delete_images', []);
-        if (!empty($deleteIds)) {
-            $images = $diary->images()->whereIn('id', $deleteIds)->get();
-            foreach ($images as $image) {
-                Storage::disk('public')->delete($image->path);
-                $image->delete();
-            }
-        }
+        $this->diaryService->deleteImages($request, $diary);
 
         if ($request->hasFile('images')) {
-            foreach ($request->file('images') as $imageFile) {
-                $ext = strtolower($imageFile->getClientOriginalExtension());
-                $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
-                $path = $imageFile->storeAs('diary_images', $filename, 'public');
-                // storage/app/public/diary_imagesに保存
-                // storeは毎回ユニークなファイル名（ハッシュ由来+拡張子）を自動生成
-                $diary->images()->create(['path' => $path]);
-            }
+
+            $this->diaryService->attachImages($diary, $request->file('images'));
         }
 
         return response()->json([
@@ -184,19 +108,7 @@ class DiaryController extends Controller
     {
         Gate::authorize('delete', $diary);
 
-        // 画像のパスだけを取り出す。all()は中身を素の配列に変換
-        $paths = $diary->images()->pluck('path')->all();
-        // 親を削除、画像はCASCADEで自動削除     
-        $diary->delete();
-
-        try {
-            Storage::disk('public')->delete($paths); // ファイルの物理削除
-        } catch (Throwable $e) { // 何かしらのエラーが起きた時だけ実行、例外＆エラーを開発車向けに表示
-            Log::warning('Failed deleting diary image files', [
-                'paths' => $paths,
-                'error' => $e->getMessage(),
-            ]);
-        }
+        $this->diaryService->deleteDiary($diary);
 
         return response()->noContent(); // ボディなし
     }

--- a/app/Http/Controllers/Api/DiaryLikeController.php
+++ b/app/Http/Controllers/Api/DiaryLikeController.php
@@ -19,9 +19,10 @@ class DiaryLikeController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(Diary $diary)
+    public function index(Request $request, Diary $diary)
     {
-
+        // 日記オーナーとログインユーザーが同じでなければ、403を返す
+        // abort_unless($diary->user_id === $request->user()->id, 403);
         $likers = $this->diaryLikeService->getLikers($diary);
 
         return response()->json([
@@ -35,6 +36,7 @@ class DiaryLikeController extends Controller
      */
     public function store(Request $request, Diary $diary)
     {
+        // 公開日記としてそのユーザーにいいねを許可されていなければ403を投げる
         abort_unless($diary->isVisibleTo($request->user()), 403);
 
         $this->diaryLikeService->likeDiary($request, $diary);

--- a/app/Http/Controllers/Api/DiaryLikeController.php
+++ b/app/Http/Controllers/Api/DiaryLikeController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Diary;
+use App\Services\DiaryLikeService;
+use Illuminate\Http\Request;
+
+class DiaryLikeController extends Controller
+{
+
+    protected $diaryLikeService;
+
+    public function __construct(DiaryLikeService $diaryLikeService)
+    {
+        $this->diaryLikeService = $diaryLikeService;
+    }
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Diary $diary)
+    {
+
+        $likers = $this->diaryLikeService->getLikers($diary);
+
+        return response()->json([
+            'diary' => $diary,
+            'likers' => $likers
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request, Diary $diary)
+    {
+
+        $this->diaryLikeService->likeDiary($request, $diary);
+
+        return response()->json([
+            'ok' => true,
+            'liked' => true,
+            'count' => $diary->likes()->count(),
+        ]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Request $request, Diary $diary)
+    {
+
+        $this->diaryLikeService->unlikeDiary($request, $diary);
+
+        return response()->json([
+            'ok' => true,
+            'liked' => false,
+            'count' => $diary->likes()->count(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/DiaryLikeController.php
+++ b/app/Http/Controllers/Api/DiaryLikeController.php
@@ -35,6 +35,7 @@ class DiaryLikeController extends Controller
      */
     public function store(Request $request, Diary $diary)
     {
+        abort_unless($diary->isVisibleTo($request->user()), 403);
 
         $this->diaryLikeService->likeDiary($request, $diary);
 
@@ -50,6 +51,7 @@ class DiaryLikeController extends Controller
      */
     public function destroy(Request $request, Diary $diary)
     {
+        abort_unless($diary->isVisibleTo($request->user()), 403);
 
         $this->diaryLikeService->unlikeDiary($request, $diary);
 

--- a/app/Http/Controllers/Api/DiaryLikeController.php
+++ b/app/Http/Controllers/Api/DiaryLikeController.php
@@ -42,7 +42,7 @@ class DiaryLikeController extends Controller
             'ok' => true,
             'liked' => true,
             'count' => $diary->likes()->count(),
-        ]);
+        ], 201);
     }
 
     /**

--- a/app/Http/Controllers/Api/DiaryLikeController.php
+++ b/app/Http/Controllers/Api/DiaryLikeController.php
@@ -22,7 +22,7 @@ class DiaryLikeController extends Controller
     public function index(Request $request, Diary $diary)
     {
         // 日記オーナーとログインユーザーが同じでなければ、403を返す
-        // abort_unless($diary->user_id === $request->user()->id, 403);
+        abort_unless($diary->user_id === $request->user()->id, 403);
         $likers = $this->diaryLikeService->getLikers($diary);
 
         return response()->json([

--- a/app/Http/Controllers/Api/DiaryPublicController.php
+++ b/app/Http/Controllers/Api/DiaryPublicController.php
@@ -46,7 +46,6 @@ class DiaryPublicController extends Controller
 
         $artistName = $artistId ? Artist::find($artistId)->name : null;
 
-        // return view('public_diaries.index', compact('diaries', 'years', 'months', 'year', 'month', 'artistId', 'artistName'));
         return response()->json([
             'diaries' => $diaries,
             'years' => $years,
@@ -86,7 +85,6 @@ class DiaryPublicController extends Controller
             ])
             ->get();
 
-        // return view('public_diaries.show', compact('diary', 'comments'));
         return response()->json([
             'diary' => $diary,
             'comments' => $comments,
@@ -128,8 +126,6 @@ class DiaryPublicController extends Controller
                 ->whereNotNull('artist_id');
         })->orderBy('name')
             ->get(['id', 'name']);
-
-        // return view('public_diaries.user', compact('diaries', 'years', 'year', 'artists', 'artist', 'user'));
 
         return response()->json([
             'diaries' => $diaries,

--- a/app/Http/Controllers/Api/DiaryPublicController.php
+++ b/app/Http/Controllers/Api/DiaryPublicController.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Artist;
+use App\Models\Comment;
+use App\Models\Diary;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class DiaryPublicController extends Controller
+{
+    public function index(Request $request)
+    {
+
+        $year = $request->integer('year');
+        $month = $request->integer('month');
+        $artistId = $request->integer('artist_id');
+
+        // 自分をブロックしているユーザーのidを配列で取得
+        $blockedByUserIds = $request->user()->blockedBy()->pluck('users.id');
+        // 自分がブロックしているユーザーのidを配列で取得
+        $blockingUserIds = $request->user()->blocks()->pluck('users.id');
+
+        $diaries =  Diary::query()
+            ->where('is_public', true)
+            ->whereNotIn('user_id', $blockedByUserIds) // ブロックされているユーザーの日記を除外
+            ->whereNotIn('user_id', $blockingUserIds) // ブロックしているユーザーの日記を除外 
+            ->when($year, fn($q) => $q->whereYear('happened_on', $year))
+            ->when($month, fn($q) => $q->whereMonth('happened_on', $month))
+            ->when($artistId, fn($q) => $q->where('artist_id', $artistId))
+            ->with(['artist', 'coverImage', 'user'])
+            ->withCount(['comments', 'likes'])
+            ->withExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())])
+            ->orderBy('happened_on', 'desc')
+            ->orderBy('updated_at', 'desc')
+            ->paginate(12)
+            ->withQueryString();
+
+        $minDate = Diary::where('is_public', true)->min('happened_on');
+        $minYear = $minDate ? Carbon::parse($minDate)->year : 2021;
+        $years = range(now()->year, $minYear);
+        $months = range(1, 12);
+
+        $artistName = $artistId ? Artist::find($artistId)->name : null;
+
+        // return view('public_diaries.index', compact('diaries', 'years', 'months', 'year', 'month', 'artistId', 'artistName'));
+        return response()->json([
+            'diaries' => $diaries,
+            'years' => $years,
+            'months' => $months,
+            'year' => $year,
+            'month' => $month,
+            'artistId' => $artistId,
+            'artistName' => $artistName,
+        ]);
+    }
+
+    public function show(Diary $diary)
+    {
+        abort_unless($diary->is_public, 403); // 公開フラグがなければ403
+        // ログインユーザーが日記のユーザーからブロックされていれば、日記にアクセス不可。
+        if ($diary->user->isBlocking(auth()->user())) {
+            abort(403);
+        }
+
+        $diary->load(['user'])
+            ->loadCount(['likes', 'comments'])
+            ->loadExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())]);
+
+        // コメントをlikes_count / liked_by_me 付きで取得
+        // コメントへの返信を多層化：親コメントは新着順、返信コメントは古い順にソート
+        // 親を除く全ての返信数をカウント
+        $comments = Comment::query()
+            ->leftJoin('comments as r', 'r.id', '=', 'comments.root_id')
+            ->where('comments.diary_id', $diary->id)
+            ->orderByDesc('r.created_at')
+            ->orderBy('comments.path')
+            ->select('comments.*')
+            ->with('user')
+            ->withCount(['replies', 'likes'])
+            ->withExists([
+                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
+            ])
+            ->get();
+
+        // return view('public_diaries.show', compact('diary', 'comments'));
+        return response()->json([
+            'diary' => $diary,
+            'comments' => $comments,
+        ]);
+    }
+
+    public function user(User $user, Request $request)
+    {
+        // ログインユーザーが日記のユーザーからブロックされていれば、日記にアクセス不可。
+        if ($user->isBlocking($request->user())) {
+            abort(403);
+        }
+
+        $year = $request->integer('year');
+        $artist = $request->integer('artist');
+
+        $diaries = Diary::query()
+            ->where('is_public', true)
+            ->where('user_id', $user->id)
+            ->when($year, fn($q) => $q->whereYear('happened_on', $year))
+            ->when($artist, fn($q) => $q->where('artist_id', $artist))
+            ->with(['artist', 'coverImage', 'user'])
+            ->withCount(['comments', 'likes'])
+            ->withExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())])
+            ->orderBy('happened_on', 'desc')
+            ->orderBy('updated_at', 'desc')
+            ->paginate(6)
+            ->withQueryString();
+
+        $minDate = Diary::min('happened_on');
+        // 日付を扱う時はCarbonが便利
+        $minYear = $minDate ? Carbon::parse($minDate)->year : 2021;
+        $years = range(now()->year, $minYear);
+
+        $artists = Artist::whereIn('id', function ($q)  use ($user) {
+            $q->select('artist_id')
+                ->from('diaries') // diariesからartist_idの一覧を取り出す
+                ->where('user_id', $user->id) // そのユーザーが書いた日記に限定
+                ->whereNotNull('artist_id');
+        })->orderBy('name')
+            ->get(['id', 'name']);
+
+        // return view('public_diaries.user', compact('diaries', 'years', 'year', 'artists', 'artist', 'user'));
+
+        return response()->json([
+            'diaries' => $diaries,
+            'years' => $years,
+            'year' => $year,
+            'artists' => $artists,
+            'artist' => $artist,
+            'user' => $user,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/DiaryPublicController.php
+++ b/app/Http/Controllers/Api/DiaryPublicController.php
@@ -65,7 +65,7 @@ class DiaryPublicController extends Controller
             abort(403);
         }
 
-        $diary->load(['user'])
+        $diary->load(['user', 'artist', 'images'])
             ->loadCount(['likes', 'comments'])
             ->loadExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())]);
 

--- a/app/Http/Controllers/Api/DiaryPublicController.php
+++ b/app/Http/Controllers/Api/DiaryPublicController.php
@@ -59,11 +59,7 @@ class DiaryPublicController extends Controller
 
     public function show(Diary $diary)
     {
-        abort_unless($diary->is_public, 403); // 公開フラグがなければ403
-        // ログインユーザーが日記のユーザーからブロックされていれば、日記にアクセス不可。
-        if ($diary->user->isBlocking(auth()->user())) {
-            abort(403);
-        }
+        abort_unless($diary->isVisibleTo(auth()->user()), 403);
 
         $diary->load(['user', 'artist', 'images'])
             ->loadCount(['likes', 'comments'])

--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -12,7 +12,6 @@ class NotificationController extends Controller
         $notifications = $request->user()->notifications()
             ->latest()->paginate(20);
 
-        // return view('notifications.index', compact('notifications'));
         return response()->json([
             'notifications' => $notifications,
         ]);
@@ -35,7 +34,6 @@ class NotificationController extends Controller
         if (is_null($n->read_at)) $n->markAsRead();
         // 未読ならmarkAsRead()->read_atに現在時刻が入る。
 
-        // return back();
         return response()->json([
             'ok' => true,
         ]);
@@ -47,7 +45,6 @@ class NotificationController extends Controller
         $request->user()->unreadNotifications()
             ->update(['read_at' => now()]);
 
-        // return back();
         return response()->json([
             'ok' => true,
         ]);
@@ -59,7 +56,17 @@ class NotificationController extends Controller
         $n = $request->user()->notifications()->findOrFail($id);
         $n->delete();
 
-        // return back();
+        return response()->json([
+            'ok' => true,
+        ]);
+    }
+
+    // 既読通知を未読に戻す
+    public function markUnread(Request $request, string $id)
+    {
+        $n = $request->user()->notifications()->findOrFail($id);
+        $n->update(['read_at' => null]);
+
         return response()->json([
             'ok' => true,
         ]);

--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function index(Request $request)
+    {
+        $notifications = $request->user()->notifications()
+            ->latest()->paginate(20);
+
+        // return view('notifications.index', compact('notifications'));
+        return response()->json([
+            'notifications' => $notifications,
+        ]);
+    }
+
+    // 通知の未読件数だけを返す
+    public function unreadCount(Request $request)
+    {
+        // return ['count' => $request->user()->unreadNotifications()->count()];
+        // count()の結果を配列で返す→LaravelがJSONにして返却({"count":N})
+        return response()->json([
+            'count' => $request->user()->unreadNotifications()->count(),
+        ]);
+    }
+
+    // 単一の通知を既読にする
+    public function markRead(Request $request, string $id)
+    {
+        $n = $request->user()->notifications()->findOrFail($id);
+        if (is_null($n->read_at)) $n->markAsRead();
+        // 未読ならmarkAsRead()->read_atに現在時刻が入る。
+
+        // return back();
+        return response()->json([
+            'ok' => true,
+        ]);
+    }
+
+    // 未読通知を一括で既読にする
+    public function markAllRead(Request $request)
+    {
+        $request->user()->unreadNotifications()
+            ->update(['read_at' => now()]);
+
+        // return back();
+        return response()->json([
+            'ok' => true,
+        ]);
+    }
+
+    // 通知の削除
+    public function destroy(Request $request, string $id)
+    {
+        $n = $request->user()->notifications()->findOrFail($id);
+        $n->delete();
+
+        // return back();
+        return response()->json([
+            'ok' => true,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/PasswordController.php
+++ b/app/Http/Controllers/Api/PasswordController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password;
+
+class PasswordController extends Controller
+{
+    /**
+     * Update the user's password.
+     */
+    public function update(Request $request)
+    {
+        $validated = $request->validate([
+            'current_password' => ['required', 'current_password:sanctum'],
+            'password' => ['required', Password::defaults(), 'confirmed'],
+        ]);
+
+        $request->user()->update([
+            'password' => Hash::make($validated['password']),
+        ]);
+
+        return response()->json([
+            'message' => 'Password is updated successfully!'
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -11,6 +11,7 @@ class ProfileController extends Controller
 {
     /**
      * Update the user's profile information(email).
+     * メールアドレスの更新
      */
     public function update(Request $request)
     {
@@ -46,6 +47,9 @@ class ProfileController extends Controller
         ]);
     }
 
+    /**
+     * アカウントの削除
+     */
     public function destroy(Request $request)
     {
         $request->validate([

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class ProfileController extends Controller
+{
+    /**
+     * Update the user's profile information(email).
+     */
+    public function update(Request $request)
+    {
+        // バリデーション emailのみ リクエストクラスはnameとemailのため使わず
+        $validated = $request->validate([
+            'email' => [
+                'required',
+                'string',
+                'lowercase',
+                'email',
+                'max:255',
+                Rule::unique(User::class)->ignore($request->user()->id),
+            ]
+        ]);
+        // $request->user(): Sanctumトークンで認証済みの現在のユーザーモデルを取得
+        // fill(..): 取得した値をモデルの属性にまとめてセットする。
+        $request->user()->fill($validated);
+
+        // isDirty('email): fill()した結果、email属性の値がDBから読み込んだ元の値と
+        // 実際に変わっているかを判定するEloquentのメソッド（変更されていなければfalse）
+        if ($request->user()->isDirty('email')) {
+            // 変更されていたらemail_verified_atをnullに戻す。
+            // これは「メールを変えたら再検証が必要」という意図のコードだが、実際に確認メールを送るロジックは
+            // このプロジェクトにはまだ存在しない(MustVerifyEmailが無効化されているため)。
+            // なので現状は単にemail_verified_atカラムがnullになるだけ。
+            $request->user()->email_verified_at = null;
+        }
+        // DBにUPDATEクエリが発行される
+        $request->user()->save();
+
+        return response()->json([
+            'message' => 'Emailを更新しました'
+        ]);
+    }
+
+    public function destroy(Request $request)
+    {
+        $request->validate([
+            'password' => ['required', 'current_password:sanctum'],
+        ]);
+
+        $user = $request->user();
+
+        // トークンを削除
+        $user->tokens()->delete();
+        $user->delete();
+
+
+        return response()->json([
+            'message' => 'Account deleted successfully'
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/UserBlockController.php
+++ b/app/Http/Controllers/Api/UserBlockController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class UserBlockController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/Api/UserBlockController.php
+++ b/app/Http/Controllers/Api/UserBlockController.php
@@ -3,9 +3,83 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\Block;
+use App\Models\Follow;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class UserBlockController extends Controller
 {
-    //
+    /**
+     * ユーザーをブロックする
+     */
+    public function store(Request $request, User $user)
+    {
+        // 自分をブロックできない
+        Gate::authorize('block', $user);
+
+        // すでにブロック済みならOK
+        if ($request->user()->isBlocking($user)) {
+            return response()->json([
+                'ok' => true,
+                'blocking' => true,
+            ]);
+        }
+
+        // ブロックしたユーザーをフォローしていたら解除
+        if ($request->user()->isFollowing($user)) {
+            Follow::where('follower_id', $request->user()->id)
+                ->where('followed_id', $user->id)
+                ->delete();
+        }
+
+        // ブロックしたユーザーにフォローされていたら、解除。
+        if ($user->isFollowing($request->user())) {
+            Follow::where('follower_id', $user->id)
+                ->where('followed_id', $request->user()->id)
+                ->delete();
+        }
+
+        Block::firstOrCreate([
+            'blocker_id' => $request->user()->id,
+            'blocked_id' => $user->id,
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'blocking' => true,
+        ]);
+    }
+
+    /**
+     * ユーザーのブロックを解除する
+     */
+    public function destroy(Request $request, User $user)
+    {
+        // ブロック解除可能か（=自分がブロックしていたらOK）
+        Gate::authorize('unBlock', $user);
+
+        Block::where('blocker_id', $request->user()->id)
+            ->where('blocked_id', $user->id)
+            ->delete();
+
+        return response()->json([
+            'ok' => true,
+            'blocking' => false,
+        ]);
+    }
+
+    /**
+     * ブロックしているユーザーの一覧をページネーションで取得
+     */
+    public function blocks(Request $request)
+    {
+        $blocks = $request->user()->blocks()
+            ->orderByPivot('created_at', 'desc')->paginate(10)->withQueryString();
+
+        return response()->json([
+            'blocks' => $blocks,
+        ]);
+    }
 }

--- a/app/Http/Controllers/Api/UserFollowController.php
+++ b/app/Http/Controllers/Api/UserFollowController.php
@@ -60,20 +60,26 @@ class UserFollowController extends Controller
         ]);
     }
 
-    public function followers(Request $request)
+    /**
+     * $userのフォロワー一覧をページネーションで取得
+     */
+    public function followers(User $user)
     {
-        $followers = $request->user()->followers()
-            ->orderByPivot('created_at', 'desc')->paginate(20)->withQueryString();
+        $followers = $user->followers()
+            ->orderByPivot('created_at', 'desc')->paginate(10)->withQueryString();
 
         return response()->json([
             'followers' => $followers,
         ]);
     }
 
-    public function followings(Request $request)
+    /**
+     * $userがフォローしている人の一覧をページネーションで取得
+     */
+    public function followings(User $user)
     {
-        $followings = $request->user()->followings()
-            ->orderByPivot('created_at', 'desc')->paginate(20)->withQueryString();
+        $followings = $user->followings()
+            ->orderByPivot('created_at', 'desc')->paginate(10)->withQueryString();
 
         return response()->json([
             'followings' => $followings,

--- a/app/Http/Controllers/Api/UserFollowController.php
+++ b/app/Http/Controllers/Api/UserFollowController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Follow;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+
+class UserFollowController extends Controller
+{
+    /**
+     * ユーザーフォロー情報を保存
+     */
+    public function store(Request $request, User $user)
+    {
+        Gate::authorize('follow', $user);
+
+        // すでにフォロー済みならOKで返す
+        if ($request->user()->isFollowing($user)) {
+            return response()->json([
+                'ok' => true,
+                'following' => true,
+                'followings_count' => $user->followings()->count(),
+                'followers_count' => $user->followers()->count(),
+            ]);
+        }
+
+        Follow::firstOrCreate([
+            'follower_id' => $request->user()->id,
+            'followed_id' => $user->id,
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'following' => true,
+            'followings_count' => $user->followings()->count(),
+            'followers_count' => $user->followers()->count(),
+        ]);
+    }
+
+    /**
+     * フォロー解除
+     */
+    public function destroy(Request $request, User $user)
+    {
+        Gate::authorize('unfollow', $user);
+
+        Follow::where('follower_id', $request->user()->id)
+            ->where('followed_id', $user->id)
+            ->delete();
+
+        return response()->json([
+            'ok' => true,
+            'following' => false,
+            'followings_count' => $user->followings()->count(),
+            'followers_count' => $user->followers()->count(),
+        ]);
+    }
+
+    public function followers(Request $request)
+    {
+        $followers = $request->user()->followers()
+            ->orderByPivot('created_at', 'desc')->paginate(20)->withQueryString();
+
+        return response()->json([
+            'followers' => $followers,
+        ]);
+    }
+
+    public function followings(Request $request)
+    {
+        $followings = $request->user()->followings()
+            ->orderByPivot('created_at', 'desc')->paginate(20)->withQueryString();
+
+        return response()->json([
+            'followings' => $followings,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -24,10 +24,12 @@ class UserProfileController extends Controller
             'followers'
         ]);
         $isFollowing = $request->user()->isFollowing($user);
+        $isBlocking = $request->user()->isBlocking($user);
 
         return response()->json([
             'user' => $user,
             'is_following' => $isFollowing,
+            'is_blocking' => $isBlocking,
         ]);
     }
 

--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
+
 
 
 class UserProfileController extends Controller
@@ -19,6 +21,51 @@ class UserProfileController extends Controller
         $user->loadCount([
             'diaries as public_diaries_count' => fn($q) => $q->where('is_public', true)
         ]);
+        return response()->json([
+            'user' => $user,
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        $user = $request->user();
+
+        $deleteIcon = $request->boolean('delete_icon');
+
+        $data = $request->validateWithBag('profile', [
+            'name' => 'required|string|max:255',
+            'icon' => 'nullable|image|mimes:jpg,jpeg,png,webp|max:2048',
+            'profile' => 'nullable|string|max:1000'
+        ]);
+
+        $user->name = $data['name'];
+
+        if ($deleteIcon) {
+            if ($user->icon_path) {
+                Storage::disk('public')->delete($user->icon_path);
+            }
+            $user->icon_path = null;
+        } elseif ($request->hasFile('icon')) {
+            // 古いファイルを削除
+            if ($user->icon_path) {
+                Storage::disk('public')->delete($user->icon_path);
+            }
+            // 新しいファイル名を生成
+            $ext = strtolower($request->file('icon')->getClientOriginalExtension());
+            $filename = $user->id . '_' . now()->format('YmdHis') . '.' . $ext;
+            // 新しいファイルを保存
+            $path = $request->file('icon')->storeAs('profile_icons', $filename, 'public');
+            // DBにパスを保存
+            $user->icon_path = $path;
+        }
+
+        // プロフィール文（空文字→nullでクリア）
+        if ($request->has('profile')) {
+            $user->profile = ($data['profile'] === '') ? null : $data['profile'];
+        }
+
+        $user->save();
+
         return response()->json([
             'user' => $user,
         ]);

--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -15,14 +15,19 @@ class UserProfileController extends Controller
     /**
      * Display the user's profile information.
      */
-    public function show(User $user)
+    public function show(Request $request, User $user)
     {
         Gate::authorize('view', $user);
         $user->loadCount([
-            'diaries as public_diaries_count' => fn($q) => $q->where('is_public', true)
+            'diaries as public_diaries_count' => fn($q) => $q->where('is_public', true),
+            'followings',
+            'followers'
         ]);
+        $isFollowing = $request->user()->isFollowing($user);
+
         return response()->json([
             'user' => $user,
+            'is_following' => $isFollowing,
         ]);
     }
 

--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+
+class UserProfileController extends Controller
+{
+    /**
+     * Display the user's profile information.
+     */
+    public function show(User $user)
+    {
+        Gate::authorize('view', $user);
+        $user->loadCount([
+            'diaries as public_diaries_count' => fn($q) => $q->where('is_public', true)
+        ]);
+        return response()->json([
+            'user' => $user,
+        ]);
+    }
+}

--- a/app/Http/Controllers/DiaryController.php
+++ b/app/Http/Controllers/DiaryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Diary;
 use App\Models\Artist;
 use App\Models\Comment;
+use App\Services\DiaryService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
@@ -15,40 +16,29 @@ use Throwable;
 
 class DiaryController extends Controller
 {
+    // オブジェクトが持つ変数（プロパティ）として宣言。他のメソッドから $this->diaryService で使える
+    protected $diaryService;
+
+    // コンストラクタ：クラスのインスタンス生成時に自動で呼ばれる
+    // 引数に型（DiaryService）を書くだけで、Laravelが自動で new DiaryService() して渡してくれる（依存性注入）
+    public function __construct(DiaryService $diaryService)
+    {
+        // 引数で受け取った $diaryService をプロパティに保存する
+        // $this = このオブジェクト自身を指す特別な変数
+        $this->diaryService = $diaryService;
+    }
     /**
      * Display a listing of the resource.
      */
     public function index(Request $request)
     {
-        $user = $request->user();
-
-        $year = $request->integer('year');
-        $artist = $request->integer('artist');
-
-        $diaries = $user->diaries()
-            ->with(['artist', 'coverImage'])
-            // when:$yearがあれば、関数を実行。if($year)と同じ
-            ->when($year, fn($q) => $q->whereYear('happened_on', $year))
-            ->when($artist, fn($q) => $q->where('artist_id', $artist))
-            ->withCount(['comments', 'likes']) // コメント数、いいね数
-            ->withExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())])
-            ->orderBy('happened_on', 'desc') // まず日付の新しい順
-            ->orderBy('updated_at', 'desc') // 同じ日付の中で更新の新しい順
-            ->paginate(6) // ページネーション付きで取得
-            ->withQueryString(); // 次のページにも検索条件を引き継ぐ
-
-        $minDate = Diary::min('happened_on');
-        // 日付を扱う時はCarbonが便利
-        $minYear = $minDate ? Carbon::parse($minDate)->year : 2021;
-        $years = range(now()->year, $minYear);
-        // artist_tableからidがdiaries.artist_idに一致するものに絞り込む
-        $artists = Artist::whereIn('id', function ($q)  use ($user) {
-            $q->select('artist_id')
-                ->from('diaries') // diariesからartist_idの一覧を取り出す
-                ->where('user_id', $user->id) // そのユーザーが書いた日記に限定
-                ->whereNotNull('artist_id');
-        })->orderBy('name')
-            ->get(['id', 'name']);
+        [
+            'diaries' => $diaries,
+            'years' => $years,
+            'artists' => $artists,
+            'year' => $year,
+            'artist' => $artist,
+        ]  = $this->diaryService->allDiaries($request);
 
         return view('diaries.index', compact('diaries', 'years', 'artists', 'year', 'artist'));
     }
@@ -85,8 +75,8 @@ class DiaryController extends Controller
             'is_public' => $validated['is_public'],
         ]);
 
-        if($request->hasFile('images')) {
-            foreach($request->file('images') as $imageFile) {
+        if ($request->hasFile('images')) {
+            foreach ($request->file('images') as $imageFile) {
                 $ext = strtolower($imageFile->getClientOriginalExtension());
                 $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
                 $path = $imageFile->storeAs('diary_images', $filename, 'public');
@@ -98,7 +88,7 @@ class DiaryController extends Controller
         return redirect()
             ->route('diaries.index')
             ->with('status', '日記を保存しました')->with('status_type', 'success');
-            // セッションに一時的なデータ（フラッシュデータ）を保存するメソッド
+        // セッションに一時的なデータ（フラッシュデータ）を保存するメソッド
     }
 
     /**
@@ -109,7 +99,7 @@ class DiaryController extends Controller
         Gate::authorize('view', $diary);
 
         $diary->load(['user'])
-            ->loadCount(['comments','likes'])
+            ->loadCount(['comments', 'likes'])
             ->loadExists([
                 'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
             ]);
@@ -171,9 +161,9 @@ class DiaryController extends Controller
 
         // 画像の物理削除とDBの削除
         $deleteIds = $request->input('delete_images', []);
-        if(!empty($deleteIds)) {
+        if (!empty($deleteIds)) {
             $images = $diary->images()->whereIn('id', $deleteIds)->get();
-            foreach($images as $image) {
+            foreach ($images as $image) {
                 Storage::disk('public')->delete($image->path);
                 $image->delete();
             }
@@ -189,7 +179,7 @@ class DiaryController extends Controller
                 $diary->images()->create(['path' => $path]);
             }
         }
-        
+
         return redirect()
             ->route('diaries.show', $diary)
             ->with('status', '日記を更新しました')->with('status_type', 'success');

--- a/app/Http/Controllers/DiaryController.php
+++ b/app/Http/Controllers/DiaryController.php
@@ -2,16 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StoreDiaryRequest;
+use App\Http\Requests\UpdateDiaryRequest;
 use App\Models\Diary;
-use App\Models\Artist;
-use App\Models\Comment;
 use App\Services\DiaryService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Carbon;
-use Throwable;
 
 
 class DiaryController extends Controller
@@ -54,36 +50,13 @@ class DiaryController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreDiaryRequest $request)
     {
-        $validated = $request->validate([
-            'happened_on' => 'required|date',
-            // exists:artists,id→存在しないartist_idが入らないようにする
-            'artist_id' => 'required|integer|exists:artists,id',
-            'body' => 'required|string',
-            'images' => 'nullable|array',
-            // images.*とすることで,複数ファイル（配列）をチェック可能
-            // image:画像かどうか、mimes:許可する拡張子、max:5120 5MB
-            'images.*' => 'image|mimes:jpeg,jpg,png,webp|max:5120',
-            'is_public' => 'boolean'
-        ]);
-
-        $diary = $request->user()->diaries()->create([
-            'happened_on' => $validated['happened_on'],
-            'artist_id' => $validated['artist_id'],
-            'body' => $validated['body'],
-            'is_public' => $validated['is_public'],
-        ]);
+        $diary = $this->diaryService->createDiary($request);
 
         if ($request->hasFile('images')) {
-            foreach ($request->file('images') as $imageFile) {
-                $ext = strtolower($imageFile->getClientOriginalExtension());
-                $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
-                $path = $imageFile->storeAs('diary_images', $filename, 'public');
-                // storage/app/public/diary_imagesに保存
-                // storeは毎回ユニークなファイル名（ハッシュ由来+拡張子）を自動生成
-                $diary->images()->create(['path' => $path]);
-            }
+ 
+            $this->diaryService->attachImages($diary, $request->file('images'));
         }
         return redirect()
             ->route('diaries.index')
@@ -98,27 +71,10 @@ class DiaryController extends Controller
     {
         Gate::authorize('view', $diary);
 
-        $diary->load(['user'])
-            ->loadCount(['comments', 'likes'])
-            ->loadExists([
-                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
-            ]);
-
-        // コメントをlikes_count / liked_by_me 付きで取得
-        // コメントへの返信を多層化：親コメントは新着順、返信コメントは古い順にソート
-        // 親を除く全ての返信数をカウント
-        $comments = Comment::query()
-            ->leftJoin('comments as r', 'r.id', '=', 'comments.root_id')
-            ->where('comments.diary_id', $diary->id)
-            ->orderByDesc('r.created_at')
-            ->orderBy('comments.path')
-            ->select('comments.*')
-            ->with('user')
-            ->withCount(['replies', 'likes'])
-            ->withExists([
-                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
-            ])
-            ->get();
+        [
+            'diary' => $diary,
+            'comments' => $comments,
+        ] = $this->diaryService->showDiary($diary);
 
         return view('diaries.show', compact('diary', 'comments'));
     }
@@ -136,48 +92,17 @@ class DiaryController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Diary $diary)
+    public function update(UpdateDiaryRequest $request, Diary $diary)
     {
         Gate::authorize('update', $diary);
 
-        $validated = $request->validate([
-            'happened_on' => 'required|date',
-            // exists:artists,id→存在しないartist_idが入らないようにする
-            'artist_id' => 'required|integer|exists:artists,id',
-            'body' => 'required|string',
-            'images' => 'nullable|array',
-            'images.*' => 'image|mimes:jpeg,jpg,png,webp|max:5120',
-            'is_public' => 'boolean',
-            'delete_images' => 'nullable|array',
-            'delete_images.*' => 'integer|distinct|exists:diary_images,id',
-        ]);
+        $this->diaryService->updateDiary($request, $diary);
 
-        $diary->update([
-            'happened_on' => $validated['happened_on'],
-            'artist_id' => $validated['artist_id'],
-            'body' => $validated['body'],
-            'is_public' => $validated['is_public'],
-        ]);
-
-        // 画像の物理削除とDBの削除
-        $deleteIds = $request->input('delete_images', []);
-        if (!empty($deleteIds)) {
-            $images = $diary->images()->whereIn('id', $deleteIds)->get();
-            foreach ($images as $image) {
-                Storage::disk('public')->delete($image->path);
-                $image->delete();
-            }
-        }
+        $this->diaryService->deleteImages($request, $diary);
 
         if ($request->hasFile('images')) {
-            foreach ($request->file('images') as $imageFile) {
-                $ext = strtolower($imageFile->getClientOriginalExtension());
-                $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
-                $path = $imageFile->storeAs('diary_images', $filename, 'public');
-                // storage/app/public/diary_imagesに保存
-                // storeは毎回ユニークなファイル名（ハッシュ由来+拡張子）を自動生成
-                $diary->images()->create(['path' => $path]);
-            }
+
+            $this->diaryService->attachImages($diary, $request->file('images'));
         }
 
         return redirect()
@@ -193,19 +118,8 @@ class DiaryController extends Controller
     {
         Gate::authorize('delete', $diary);
 
-        // 画像のパスだけを取り出す。all()は中身を素の配列に変換
-        $paths = $diary->images()->pluck('path')->all();
-        // 親を削除、画像はCASCADEで自動削除     
-        $diary->delete();
+        $this->diaryService->deleteDiary($diary);
 
-        try {
-            Storage::disk('public')->delete($paths); // ファイルの物理削除
-        } catch (Throwable $e) { // 何かしらのエラーが起きた時だけ実行、例外＆エラーを開発車向けに表示
-            Log::warning('Failed deleting diary image files', [
-                'paths' => $paths,
-                'error' => $e->getMessage(),
-            ]);
-        }
 
         return redirect()
             ->route('diaries.index')

--- a/app/Http/Controllers/DiaryLikeController.php
+++ b/app/Http/Controllers/DiaryLikeController.php
@@ -3,22 +3,25 @@
 namespace App\Http\Controllers;
 
 use App\Models\Diary;
-use App\Models\User;
+use App\Services\DiaryLikeService;
 use Illuminate\Http\Request;
 
 
 class DiaryLikeController extends Controller
 {
+    protected $diaryLikeService;
+
+    public function __construct(DiaryLikeService $diaryLikeService)
+    {
+        $this->diaryLikeService = $diaryLikeService;
+    }
 
     /**
      * いいねしたユーザーの一覧を生成
      */
     public function index(Diary $diary)
     {
-        $likers = $diary->likers()
-                ->orderByPivot('created_at', 'desc') // 中間テーブルlikesのcreated_atで並べる。
-                ->paginate(10)
-                ->withQueryString();
+        $likers = $this->diaryLikeService->getLikers($diary);
 
         return view('diaries.likes.index', compact('diary', 'likers'));
     }
@@ -26,11 +29,10 @@ class DiaryLikeController extends Controller
     /**
      * いいね情報を保存、通知を作成
      */
-    public function store(Request $request ,Diary $diary)
+    public function store(Request $request, Diary $diary)
     {
-        $like = $diary->likes()->firstOrCreate([
-            'user_id' => $request->user()->id,
-        ]);
+        $this->diaryLikeService->likeDiary($request, $diary);
+
 
         return response()->json([
             'ok' => true,
@@ -43,14 +45,8 @@ class DiaryLikeController extends Controller
 
     public function destroy(Request $request, Diary $diary)
     {
-        $like = $diary->likes()
-             ->where('user_id', $request->user()->id)
-             ->first();
-        
-        if($like) {
-            $like->delete(); // モデルのdeleteなのでdeleteイベントが発火
-        }
-        
+        $this->diaryLikeService->unlikeDiary($request, $diary);
+
         return response()->json([
             'ok' => true,
             'liked' => false,

--- a/app/Http/Requests/StoreDiaryRequest.php
+++ b/app/Http/Requests/StoreDiaryRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Override;
+
+class StoreDiaryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // 実際の認可（誰がどの日記を操作できるか）はコントローラーでGate::authorize()が担当
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'happened_on' => ['required', 'date'],
+            // exists:artists,id→存在しないartist_idが入らないようにする
+            'artist_id' => ['required', 'integer', 'exists:artists,id'],
+            'body' => ['required', 'string'],
+            'images' => ['nullable', 'array'],
+            // images.*とすることで,複数ファイル（配列）をチェック可能
+            // image:画像かどうか、mimes:許可する拡張子、max:5120 5MB
+            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:5120'],
+            'is_public' => ['boolean']
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'happened_on.required' => '日付を入力してください',
+            'happened_on.date' => '日付は日付形式で入力してください',
+            'artist_id.required' => 'アーティストを入力してください',
+            'body.required' => '本文を入力してください',
+            'body.string' => '本文は文字列で入力してください',
+            'images.*.image' => '写真は画像ファイルを添付してください',
+            'images.*.mimes' => '写真はjpeg、jpg、png、webp形式で添付してください',
+            'images.*.max' => '写真のサイズは5MB以下にしてください',
+        ];
+    }
+
+    // デフォルトはリダイレクトを返すが、APIはJSONが必要なためオーバーライド
+    // #[Override]：PHP 8.3のアトリビュート。親クラスに同名メソッドがなければエラーになり、タイポを防ぐ
+    #[Override]
+    protected function failedValidation(Validator $validator)
+    {
+        if($this->expectsJson()) {
+            $response = response()->json([
+                'message' => 'Validation errors',
+                'errors' => $validator->errors()
+            ], 422);
+
+            throw new HttpResponseException($response);
+        }
+        return parent::failedValidation($validator);
+    }
+}

--- a/app/Http/Requests/UpdateDiaryRequest.php
+++ b/app/Http/Requests/UpdateDiaryRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Override;
+
+class UpdateDiaryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // 実際の認可（誰がどの日記を操作できるか）はコントローラーでGate::authorize()が担当
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'happened_on' => ['required', 'date'],
+            // exists:artists,id→存在しないartist_idが入らないようにする
+            'artist_id' => ['required', 'integer', 'exists:artists,id'],
+            'body' => ['required', 'string'],
+            'images' => ['nullable', 'array'],
+            'images.*' => ['image', 'mimes:jpeg,jpg,png,webp', 'max:5120'],
+            'is_public' => ['boolean'],
+            'delete_images' => ['nullable', 'array'],
+            'delete_images.*' => ['integer', 'distinct', 'exists:diary_images,id'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'happened_on.required' => '日付を入力してください',
+            'happened_on.date' => '日付は日付形式で入力してください',
+            'artist_id.required' => 'アーティストを入力してください',
+            'body.required' => '本文を入力してください',
+            'body.string' => '本文は文字列で入力してください',
+            'images.*.image' => '写真は画像ファイルを添付してください',
+            'images.*.mimes' => '写真はjpeg、jpg、png、webp形式で添付してください',
+            'images.*.max' => '写真のサイズは5MB以下にしてください',
+        ];
+    }
+
+    // デフォルトはリダイレクトを返すが、APIはJSONが必要なためオーバーライド
+    // #[Override]：PHP 8.3のアトリビュート。親クラスに同名メソッドがなければエラーになり、タイポを防ぐ
+    #[Override]
+    protected function failedValidation(Validator $validator)
+    {
+        if ($this->expectsJson()) {
+            $response = response()->json([
+                'message' => 'Validation errors',
+                'errors' => $validator->errors()
+            ], 422);
+
+            throw new HttpResponseException($response);
+        }
+        return parent::failedValidation($validator);
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -22,6 +22,15 @@ class Comment extends Model
         return $this->belongsTo(Diary::class);
     }
 
+    /**
+     * このコメントを、そのユーザーに閲覧・いいねを許可してよいか？
+     * （紐づく日記が閲覧可能かどうかで判定）
+     */
+    public function isVisibleTo(User $user): bool
+    {
+        return $this->diary->isVisibleOrOwnedBy($user);
+    }
+
     public function likes()
     {
         return $this->morphMany(Like::class, 'likeable');

--- a/app/Models/Diary.php
+++ b/app/Models/Diary.php
@@ -57,6 +57,24 @@ class Diary extends Model
         return $this->likes()->where('user_id', $user->id)->exists();
     }
 
+    /**
+     * 公開日記として、そのユーザーに閲覧・いいねを許可してよいか？
+     * （非公開日記、または投稿者にブロックされている場合はfalse）
+     */
+    public function isVisibleTo(User $user): bool
+    {
+        return $this->is_public && !$this->user->isBlocking($user);
+    }
+
+    /**
+     * 自分の日記、または閲覧を許可された公開日記か？
+     * （コメント投稿など、非公開でも投稿者本人には許可したい操作向け）
+     */
+    public function isVisibleOrOwnedBy(User $user): bool
+    {
+        return $this->user_id === $user->id || $this->isVisibleTo($user);
+    }
+
     public function likers()
     {
         return $this->morphToMany(User::class,  'likeable', 'likes', 'likeable_id', 'user_id')

--- a/app/Models/Diary.php
+++ b/app/Models/Diary.php
@@ -95,12 +95,22 @@ class Diary extends Model
     protected static function booted(): void
     {
         // 日記削除の直前に、関連画像をストレージから削除する
-        static::deleting(function(Diary $diary) {
+        static::deleting(function (Diary $diary) {
             // 画像テーブルからファイルパスをまとめて取り出す。
             $paths = $diary->images()->pluck('path')->filter()->values()->all();
             // 見つかったファイルを物理削除（publicディスク想定）
-            if(!empty($paths)) {
+            if (!empty($paths)) {
                 Storage::disk('public')->delete($paths);
+            }
+            // 日記自体へのいいねを削除
+            $diary->likes()->delete();
+
+            // この日記に属するコメントへのいいねも削除
+            $commentIds = $diary->comments()->pluck('id');
+            if ($commentIds->isNotEmpty()) {
+                Like::where('likeable_type', Comment::class)
+                    ->whereIn('likeable_id', $commentIds)
+                    ->delete();
             }
         });
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,12 +7,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Storage;
-
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasApiTokens;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -124,6 +124,16 @@ class User extends Authenticatable
                 Storage::disk('public')->delete($user->icon_path);
             }
 
+            // このユーザーが書いたコメント（他人の日記への分も含む）へのいいねを削除
+            // ※ comments.user_id は cascadeOnDelete のため、このユーザー削除時に
+            //   DBレベルで直接コメントが消える。DBのcascadeはEloquentイベントを
+            //   発火させないため、ここで先に手動で片付けておく必要がある。
+            $user->comments()->select('id')->chunkById(100, function($chunk) {
+                Like::where('likeable_type', Comment::class)
+                    ->whereIn('likeable_id', $chunk->pluck('id'))
+                    ->delete();
+            });
+
             // chunkById:ID順に100件ずつとりだして処理する関数
             $user->diaries()->select('id')->chunkById(100, function($chunk){
                 $chunk->each->delete(); // それぞれを削除

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -29,6 +29,7 @@ class UserPolicy
     public function follow(User $currentUser, User $targetUser): bool
     {
         if ($currentUser->id === $targetUser->id) return false; // 自己フォロー禁止
+        if ($targetUser->isBlocking($currentUser)) return false; // ブロックされたユーザーはフォロー不可
         return true;
     }
 
@@ -39,5 +40,23 @@ class UserPolicy
     {
         if ($currentUser->id === $targetUser->id) return false;
         return $currentUser->isFollowing($targetUser);
+    }
+
+    /**
+     * ブロック可能か
+     */
+    public function block(User $currentUser, User $targetUser): bool
+    {
+        if ($currentUser->id === $targetUser->id) return false; // 自分をブロックできない
+        return true;
+    }
+
+    /**
+     * ブロック解除可能か（=自分がブロックしていたらOK）
+     */
+    public function unBlock(User $currentUser, User $targetUser): bool
+    {
+        if ($currentUser->id === $targetUser->id) return false;
+        return $currentUser->isBlocking($targetUser);
     }
 }

--- a/app/Services/DiaryLikeService.php
+++ b/app/Services/DiaryLikeService.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Diary;
+use Illuminate\Http\Request;
+
+class DiaryLikeService
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    public function getLikers(Diary $diary)
+    {
+        $likers = $diary->likers()
+            ->orderByPivot('created_at', 'desc') // 中間テーブルlikesのcreated_atで並べる。
+            ->paginate(10)
+            ->withQueryString();
+
+
+        return $likers;
+    }
+
+    public function likeDiary(Request $request, Diary $diary)
+    {
+        $diary->likes()->firstOrCreate([
+            'user_id' => $request->user()->id,
+        ]);
+    }
+
+    public function unlikeDiary(Request $request, Diary $diary)
+    {
+        $like = $diary->likes()
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if ($like) {
+            $like->delete(); // モデルのdeleteなのでdeleteイベントが発火
+        }
+    }
+}

--- a/app/Services/DiaryService.php
+++ b/app/Services/DiaryService.php
@@ -3,9 +3,13 @@
 namespace App\Services;
 
 use App\Models\Artist;
+use App\Models\Comment;
 use App\Models\Diary;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
 
 class DiaryService
 {
@@ -56,5 +60,108 @@ class DiaryService
             'year' => $year,
             'artist' => $artist,
         ];
+    }
+
+    public function createDiary(Request $request)
+    {
+        // FormRequestがコントローラー到達前にバリデーションを実行済み。validated()で合格データを取り出すだけ
+        $validated = $request->validated();
+        $diary = $request->user()->diaries()->create([
+            'happened_on' => $validated['happened_on'],
+            'artist_id' => $validated['artist_id'],
+            'body' => $validated['body'],
+            'is_public' => $validated['is_public'] ?? false,
+        ]);
+
+        return $diary;
+    }
+
+    // 画像ファイルにカスタムパスを設定し、保存
+    public function attachImages(Diary $diary, array $imageFiles): void
+    {
+        foreach ($imageFiles as $imageFile) {
+            $ext = strtolower($imageFile->getClientOriginalExtension());
+            // diary_id＋日時＋uniqidの組み合わせでファイル名の衝突を防ぐ
+            $filename = $diary->id . '_' . now()->format('YmdHis') . '_' . uniqid() . '.' . $ext;
+            $path = $imageFile->storeAs('diary_images', $filename, 'public');
+            // storage/app/public/diary_imagesに保存
+            // storeは毎回ユニークなファイル名（ハッシュ由来+拡張子）を自動生成
+            $diary->images()->create(['path' => $path]);
+        }
+    }
+
+    public function showDiary(Diary $diary)
+    {
+        $diary->load(['user'])
+            ->loadCount(['comments', 'likes'])
+            ->loadExists([
+                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
+            ]);
+
+        // コメントをlikes_count / liked_by_me 付きで取得
+        // コメントへの返信を多層化：親コメントは新着順、返信コメントは古い順にソート
+        // 親を除く全ての返信数をカウント
+        $comments = Comment::query()
+            ->leftJoin('comments as r', 'r.id', '=', 'comments.root_id')
+            ->where('comments.diary_id', $diary->id)
+            ->orderByDesc('r.created_at')
+            ->orderBy('comments.path')
+            ->select('comments.*')
+            ->with('user')
+            ->withCount(['replies', 'likes'])
+            ->withExists([
+                'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),
+            ])
+            ->get();
+
+        return [
+            'diary' => $diary,
+            'comments' => $comments,
+        ];
+    }
+
+    public function updateDiary(Request $request, Diary $diary): void
+    {
+        // PHPのオブジェクトは参照ハンドルで渡されるため、update()の変更は呼び出し元にも反映される（return不要）
+        $validated = $request->validated();
+
+        $diary->update([
+            'happened_on' => $validated['happened_on'],
+            'artist_id' => $validated['artist_id'],
+            'body' => $validated['body'],
+            'is_public' => $validated['is_public'],
+        ]);
+
+    }
+
+    public function deleteImages(Request $request, Diary $diary)
+    {
+        // delete_imagesはnullable。未送信時はデフォルトの空配列を使い、if文でスキップする
+        $deleteIds = $request->input('delete_images', []);
+        if (!empty($deleteIds)) {
+            $images = $diary->images()->whereIn('id', $deleteIds)->get();
+            foreach ($images as $image) {
+                Storage::disk('public')->delete($image->path);
+                $image->delete();
+            }
+        }
+    }
+
+    public function deleteDiary(Diary $diary)
+    {
+        // $diary->delete()より前にパスを取得する。削除後はimages()リレーションが参照できなくなるため
+        // all()はCollectionを素のPHP配列に変換する
+        $paths = $diary->images()->pluck('path')->all();
+        // 親レコードを削除。diary_imagesはCASCADE設定によりDBから自動削除される
+        $diary->delete();
+
+        try {
+            Storage::disk('public')->delete($paths); // ファイルの物理削除
+        } catch (Throwable $e) { // 何かしらのエラーが起きた時だけ実行、例外＆エラーを開発者向けに表示
+            Log::warning('Failed deleting diary image files', [
+                'paths' => $paths,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/app/Services/DiaryService.php
+++ b/app/Services/DiaryService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Artist;
+use App\Models\Diary;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class DiaryService
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    public function allDiaries(Request $request)
+    {
+        $user = $request->user();
+
+        $year = $request->integer('year');
+        $artist = $request->integer('artist');
+
+        $diaries = $user->diaries()
+            ->with(['artist', 'coverImage'])
+            // when:$yearがあれば、関数を実行。if($year)と同じ
+            ->when($year, fn($q) => $q->whereYear('happened_on', $year))
+            ->when($artist, fn($q) => $q->where('artist_id', $artist))
+            ->withCount(['comments', 'likes']) // コメント数、いいね数
+            ->withExists(['likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id())])
+            ->orderBy('happened_on', 'desc') // まず日付の新しい順
+            ->orderBy('updated_at', 'desc') // 同じ日付の中で更新の新しい順
+            ->paginate(6) // ページネーション付きで取得
+            ->withQueryString(); // 次のページにも検索条件を引き継ぐ
+
+        $minDate = Diary::min('happened_on');
+        // 日付を扱う時はCarbonが便利
+        $minYear = $minDate ? Carbon::parse($minDate)->year : 2021;
+        $years = range(now()->year, $minYear);
+        // artist_tableからidがdiaries.artist_idに一致するものに絞り込む
+        $artists = Artist::whereIn('id', function ($q)  use ($user) {
+            $q->select('artist_id')
+                ->from('diaries') // diariesからartist_idの一覧を取り出す
+                ->where('user_id', $user->id) // そのユーザーが書いた日記に限定
+                ->whereNotNull('artist_id');
+        })->orderBy('name')
+            ->get(['id', 'name']);
+
+        return [
+            'diaries' => $diaries,
+            'years' => $years,
+            'artists' => $artists,
+            'year' => $year,
+            'artist' => $artist,
+        ];
+    }
+}

--- a/app/Services/DiaryService.php
+++ b/app/Services/DiaryService.php
@@ -92,7 +92,7 @@ class DiaryService
 
     public function showDiary(Diary $diary)
     {
-        $diary->load(['user', 'artist'])
+        $diary->load(['user', 'artist', 'images'])
             ->loadCount(['comments', 'likes'])
             ->loadExists([
                 'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),

--- a/app/Services/DiaryService.php
+++ b/app/Services/DiaryService.php
@@ -92,7 +92,7 @@ class DiaryService
 
     public function showDiary(Diary $diary)
     {
-        $diary->load(['user'])
+        $diary->load(['user', 'artist'])
             ->loadCount(['comments', 'likes'])
             ->loadExists([
                 'likes as liked_by_me' => fn($q) => $q->where('user_id', auth()->id()),

--- a/app/Services/GeminiClient.php
+++ b/app/Services/GeminiClient.php
@@ -2,7 +2,6 @@
 
 namespace App\Services;
 
-use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -16,7 +15,10 @@ class GeminiClient
         //
     }
 
-    public function generate(array $history, string $userPrompt): string
+    // Gemini APIのエンドポイント
+    private const ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/interactions';
+
+    public function generate(?string $previousInteractionId, string $userPrompt): array
     {
         //  AIに渡す最初のルール文
         $system = <<<TXT
@@ -37,50 +39,37 @@ class GeminiClient
         - 情報が不足して文案が作れない場合のみ、必要な要素を一つだけ質問してください。
         TXT;
 
-        // 過去の会話履歴を追加
-        $contents = [];
-        foreach ($history as $turn) {
-            $contents[] = [
-                'role' => $turn['role'] === 'model' ? 'model' : 'user',
-                'parts' => [['text' => $turn['text']]],
-            ];
-        }
-        //  今回ユーザーが入力した内容を追加
-        $contents[] = ['role' => 'user', 'parts' => [['text' => $userPrompt]]];
-
-        //  Gemini API の呼び出し先URLを作成
-        $endpoint = "https://generativelanguage.googleapis.com/v1beta/models/"
-            . config('services.gemini.model') . ":generateContent";
-
-        //  Geminiに送るデータ
+        // Geminiに送るデータ
         $payload = [
-            'systemInstruction' => [
-                'parts' => [['text' => $system]],
-            ],
-            'contents' => $contents,
+            'model' => config('services.gemini.model'),
+            'system_instruction' => $system,
+            'input' => $userPrompt,
             'tools' => [
-                [
-                    'google_search' => new \stdClass()
-                ]
+                ['type' => 'google_search'],
             ],
-            'generationConfig' => [
+            'generation_config' => [
                 'temperature' => 0.7,
-                'maxOutputTokens' => 2048,
-                'topP' => 0.9,
-                'topK' => 40,
+                'max_output_tokens' => 2048,
+                'top_p' => 0.9,
             ],
         ];
+
+        // 会話のidを'previous_interaction_id'に入れることで、会話の履歴を追う
+        if ($previousInteractionId !== null) {
+            $payload['previous_interaction_id'] = $previousInteractionId;
+        }
+
+
         //  APIを呼び出す（45秒でタイムアウト）
         $res = Http::withHeaders([
             'x-goog-api-key' => config('services.gemini.api_key'),
-            ])
+        ])
             ->connectTimeout(5)
             ->timeout(45)
             ->retry(2, 800, throw: false)
-            ->post($endpoint, $payload);
+            ->post(self::ENDPOINT, $payload); // $thisではなくselfを使う
 
-
-        //  失敗したらログに残してエラーにする
+        // 失敗したらログに残してエラーにする
         if (!$res->successful()) {
             Log::warning('Gemini API error', [
                 'status' => $res->status(),
@@ -91,23 +80,25 @@ class GeminiClient
 
         //  成功したらレスポンスのJSONを取り出す
         $data = $res->json();
+        // 会話のidを取り出す
+        $interactionId = data_get($data, 'id');
 
-        $text = '';
-
-        // data_get:ネストされた配列やオブジェクトからパーツ配列を取得、存在しない場合、空配列を返す
-        $parts = data_get($data, 'candidates.0.content.parts', []);
-
-        $text = collect($parts) // 配列をコレクションに変換
+        // data_get:ネストされた配列やオブジェクトからstepsの配列を取得、存在しない場合、空配列を返す
+        $text = collect(data_get($data, 'steps', [])) // 配列をコレクションに変換
+            ->where('type', 'model_output')
+            ->flatMap(fn($step) => data_get($step, 'content', []))
+            ->where('type', 'text')
             ->pluck('text') // 各パーツから'text'キーの値だけを取り出す
             ->implode(''); // それらを空文字で連結する
 
         // blank():nullも空文字もfalseも全部チェック
-        if(blank($text)) {
+        if (blank($text)) {
             // なぜ空だったのかをログに残す
             Log::error('Gemini API Error: Text is empty', ['response_data' => $data]);
             throw new \RuntimeException('AIから有効なテキストが返りません');
         }
 
-        return $text;
+
+        return ['text' => $text, 'interaction_id' => $interactionId];
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72072101ccb0c563c8ab124f5cc9d635",
+    "content-hash": "b45761c9cc5f2d602e39260563a1b2b0",
     "packages": [
         {
             "name": "brick/math",
@@ -1328,6 +1328,69 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.6"
             },
             "time": "2025-07-07T14:17:42+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-04-30T11:46:25+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for cross-origin resource sharing
+    | or "CORS". This determines what cross-origin operations may execute
+    | in web browsers. You are free to adjust these settings as needed.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+
+    'allowed_methods' => ['*'],
+
+    'allowed_origins' => ['http://localhost:3000'],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => false,
+
+];

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => AuthenticateSession::class,
+        'encrypt_cookies' => EncryptCookies::class,
+        'validate_csrf_token' => ValidateCsrfToken::class,
+    ],
+
+];

--- a/database/migrations/2025_10_28_173851_add_parent_id_to_comments_table.php
+++ b/database/migrations/2025_10_28_173851_add_parent_id_to_comments_table.php
@@ -12,6 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('comments', function (Blueprint $table) {
+            // 親コメントが削除されたらそれを参照しているレコード(返信)も自動的に削除する
             $table->foreignId('parent_id')->nullable()->constrained('comments')->cascadeOnDelete();
         });
     }

--- a/database/migrations/2026_05_06_153626_create_personal_access_tokens_table.php
+++ b/database/migrations/2026_05_06_153626_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/database/migrations/2026_07_30_000000_drop_unique_name_from_artists_table.php
+++ b/database/migrations/2026_07_30_000000_drop_unique_name_from_artists_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->dropUnique(['name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->unique('name');
+        });
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
+        platform: linux/amd64
         links:
             - mysql:mysql
         ports:
@@ -11,6 +12,8 @@ services:
             PMA_HOST: mysql
         networks:
             - sail
+        depends_on:
+            - mysql
     laravel.test:
         build:
             context: './vendor/laravel/sail/runtimes/8.4'

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\AiDiaryController;
 use App\Http\Controllers\Api\ArtistController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\CommentController;
@@ -42,6 +43,10 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // whereNumber: 数字に限定する、それ以外はルーティング層で404にできる。
     Route::get('/users/{user}', [UserProfileController::class, 'show'])->whereNumber('user');
+    Route::PUT('/user_profile', [UserProfileController::class, 'update']);
+
+    Route::post('/ai/diary-suggest', [AiDiaryController::class, 'suggest']);
+    Route::post('/ai/diary-reset', [AiDiaryController::class, 'reset']);
 
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\DiaryController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -10,5 +11,9 @@ Route::post('/login', [AuthController::class, 'login']);
 Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('diaries', DiaryController::class);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\DiaryController;
+use App\Http\Controllers\Api\DiaryPublicController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -15,5 +16,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('diaries', DiaryController::class);
+    Route::get('public-diaries', [DiaryPublicController::class, 'index']);
+    Route::get('public-diaries/{diary}', [DiaryPublicController::class, 'show']);
+    Route::get('public-diaries/users/{user}', [DiaryPublicController::class, 'user']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\CommentLikeController;
 use App\Http\Controllers\Api\DiaryController;
 use App\Http\Controllers\Api\DiaryLikeController;
 use App\Http\Controllers\Api\DiaryPublicController;
+use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\PasswordController;
 use App\Http\Controllers\Api\ProfileController;
 use App\Http\Controllers\Api\UserProfileController;
@@ -54,5 +55,13 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update']);
     Route::delete('/profile', [ProfileController::class, 'destroy']);
     Route::put('/password', [PasswordController::class, 'update']);
+});
+
+Route::prefix('notifications')->middleware('auth:sanctum')->group(function () {
+    Route::get('/', [NotificationController::class, 'index']);
+    Route::post('/mark-all-read', [NotificationController::class, 'markAllRead']);
+    Route::post('/{id}/read', [NotificationController::class, 'markRead']);
+    Route::delete('/{id}', [NotificationController::class, 'destroy']);
+    Route::get('/unread-Count', [NotificationController::class, 'unreadCount']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,8 @@ use App\Http\Controllers\Api\DiaryPublicController;
 use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\PasswordController;
 use App\Http\Controllers\Api\ProfileController;
+use App\Http\Controllers\Api\UserBlockController;
+use App\Http\Controllers\Api\UserFollowController;
 use App\Http\Controllers\Api\UserProfileController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -55,6 +57,16 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update']);
     Route::delete('/profile', [ProfileController::class, 'destroy']);
     Route::put('/password', [PasswordController::class, 'update']);
+
+    Route::post('/users/{user}/follow', [UserFollowController::class, 'store']);
+    Route::delete('/users/{user}/follow', [UserFollowController::class, 'destroy']);
+    Route::get('/user-follow/followers', [UserFollowController::class, 'followers']);
+    Route::get('/user-follow/followings', [UserFollowController::class, 'followings']);
+
+    Route::post('/users/{user}/block', [UserBlockController::class, 'store']);
+    Route::delete('/users/{user}/block', [UserBlockController::class, 'destroy']);
+    Route::get('/user-block/blocks', [UserBlockController::class, 'blocks']);
+    // Route::delete('/blocks/bulk-destroy', [UserBlockController::class, 'bulkDestroy'])->name('blocks.bulk-destroy');
 });
 
 Route::prefix('notifications')->middleware('auth:sanctum')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -62,6 +62,7 @@ Route::prefix('notifications')->middleware('auth:sanctum')->group(function () {
     Route::post('/mark-all-read', [NotificationController::class, 'markAllRead']);
     Route::post('/{id}/read', [NotificationController::class, 'markRead']);
     Route::delete('/{id}', [NotificationController::class, 'destroy']);
-    Route::get('/unread-Count', [NotificationController::class, 'unreadCount']);
+    Route::get('/unread-count', [NotificationController::class, 'unreadCount']);
+    // Route::post('/{id}/mark-unread', [NotificationController::class, 'markUnread']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -78,3 +78,8 @@ Route::prefix('notifications')->middleware('auth:sanctum')->group(function () {
     Route::post('/{id}/mark-unread', [NotificationController::class, 'markUnread']);
 });
 
+Route::middleware(['auth:sanctum', 'can:access-admin'])->prefix('admin')->group(function () {
+    Route::apiResource('artists', ArtistController::class)->except(['show']);
+    // 他に管理者限定のものがあればここへ
+});
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,7 +65,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::post('/users/{user}/block', [UserBlockController::class, 'store']);
     Route::delete('/users/{user}/block', [UserBlockController::class, 'destroy']);
-    Route::get('/user-block/blocks', [UserBlockController::class, 'blocks']);
+    Route::get('/users/user-blocks', [UserBlockController::class, 'blocks']);
     // Route::delete('/blocks/bulk-destroy', [UserBlockController::class, 'bulkDestroy'])->name('blocks.bulk-destroy');
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\DiaryController;
 use App\Http\Controllers\Api\DiaryLikeController;
 use App\Http\Controllers\Api\DiaryPublicController;
@@ -24,5 +25,10 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/diaries/{diary}/likes', [DiaryLikeController::class, 'index']);
     Route::post('/diaries/{diary}/like', [DiaryLikeController::class, 'store']);
     Route::delete('/diaries/{diary}/like', [DiaryLikeController::class, 'destroy']);
+
+    Route::post('/diaries/{diary}/comments', [CommentController::class, 'store'])->middleware('throttle:20,1'); // 簡易スパム対策（1分20件）
+    Route::delete('/comments/{comment}', [CommentController::class, 'destroy']);
+    Route::post('/diaries/{diary}/comments/reply', [CommentController::class, 'reply'])->middleware('throttle:20,1'); // 簡易スパム対策（1分20件）
+    Route::delete('/replies/{comment}', [CommentController::class, 'destroy']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,6 +63,6 @@ Route::prefix('notifications')->middleware('auth:sanctum')->group(function () {
     Route::post('/{id}/read', [NotificationController::class, 'markRead']);
     Route::delete('/{id}', [NotificationController::class, 'destroy']);
     Route::get('/unread-count', [NotificationController::class, 'unreadCount']);
-    // Route::post('/{id}/mark-unread', [NotificationController::class, 'markUnread']);
+    Route::post('/{id}/mark-unread', [NotificationController::class, 'markUnread']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\CommentLikeController;
 use App\Http\Controllers\Api\DiaryController;
 use App\Http\Controllers\Api\DiaryLikeController;
 use App\Http\Controllers\Api\DiaryPublicController;
+use App\Http\Controllers\Api\UserProfileController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -38,6 +39,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/comments/{comment}/likes', [CommentLikeController::class, 'CommentLikers']);
 
     Route::get('/artists/search', [ArtistController::class, 'search']);
+
+    // whereNumber: 数字に限定する、それ以外はルーティング層で404にできる。
+    Route::get('/users/{user}', [UserProfileController::class, 'show'])->whereNumber('user');
 
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\DiaryController;
+use App\Http\Controllers\Api\DiaryLikeController;
 use App\Http\Controllers\Api\DiaryPublicController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -16,8 +17,12 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('diaries', DiaryController::class);
-    Route::get('public-diaries', [DiaryPublicController::class, 'index']);
-    Route::get('public-diaries/{diary}', [DiaryPublicController::class, 'show']);
-    Route::get('public-diaries/users/{user}', [DiaryPublicController::class, 'user']);
+    Route::get('/public-diaries', [DiaryPublicController::class, 'index']);
+    Route::get('/public-diaries/{diary}', [DiaryPublicController::class, 'show']);
+    Route::get('/public-diaries/users/{user}', [DiaryPublicController::class, 'user']);
+
+    Route::get('/diaries/{diary}/likes', [DiaryLikeController::class, 'index']);
+    Route::post('/diaries/{diary}/like', [DiaryLikeController::class, 'store']);
+    Route::delete('/diaries/{diary}/like', [DiaryLikeController::class, 'destroy']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Api\CommentLikeController;
 use App\Http\Controllers\Api\DiaryController;
 use App\Http\Controllers\Api\DiaryLikeController;
 use App\Http\Controllers\Api\DiaryPublicController;
+use App\Http\Controllers\Api\PasswordController;
+use App\Http\Controllers\Api\ProfileController;
 use App\Http\Controllers\Api\UserProfileController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -48,5 +50,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/ai/diary-suggest', [AiDiaryController::class, 'suggest']);
     Route::post('/ai/diary-reset', [AiDiaryController::class, 'reset']);
 
+    // アカウント設定
+    Route::patch('/profile', [ProfileController::class, 'update']);
+    Route::delete('/profile', [ProfileController::class, 'destroy']);
+    Route::put('/password', [PasswordController::class, 'update']);
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,7 +79,7 @@ Route::prefix('notifications')->middleware('auth:sanctum')->group(function () {
 });
 
 Route::middleware(['auth:sanctum', 'can:access-admin'])->prefix('admin')->group(function () {
-    Route::apiResource('artists', ArtistController::class)->except(['show']);
+    Route::apiResource('artists', ArtistController::class);
     // 他に管理者限定のものがあればここへ
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\CommentController;
+use App\Http\Controllers\Api\CommentLikeController;
 use App\Http\Controllers\Api\DiaryController;
 use App\Http\Controllers\Api\DiaryLikeController;
 use App\Http\Controllers\Api\DiaryPublicController;
@@ -30,5 +31,10 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::delete('/comments/{comment}', [CommentController::class, 'destroy']);
     Route::post('/diaries/{diary}/comments/reply', [CommentController::class, 'reply'])->middleware('throttle:20,1'); // 簡易スパム対策（1分20件）
     Route::delete('/replies/{comment}', [CommentController::class, 'destroy']);
+
+    Route::post('/comments/{comment}/like', [CommentLikeController::class, 'store']);
+    Route::delete('/comments/{comment}/like', [CommentLikeController::class, 'destroy']);
+    Route::get('/comments/{comment}/likes', [CommentLikeController::class, 'CommentLikers']);
+
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,10 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
 
-Route::get('/user', function (Request $request) {
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
+Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
-})->middleware('auth:sanctum');
+});
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,8 +60,8 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::post('/users/{user}/follow', [UserFollowController::class, 'store']);
     Route::delete('/users/{user}/follow', [UserFollowController::class, 'destroy']);
-    Route::get('/user-follow/followers', [UserFollowController::class, 'followers']);
-    Route::get('/user-follow/followings', [UserFollowController::class, 'followings']);
+    Route::get('/users/{user}/followers', [UserFollowController::class, 'followers']);
+    Route::get('/users/{user}/followings', [UserFollowController::class, 'followings']);
 
     Route::post('/users/{user}/block', [UserBlockController::class, 'store']);
     Route::delete('/users/{user}/block', [UserBlockController::class, 'destroy']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\ArtistController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\CommentLikeController;
@@ -35,6 +36,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/comments/{comment}/like', [CommentLikeController::class, 'store']);
     Route::delete('/comments/{comment}/like', [CommentLikeController::class, 'destroy']);
     Route::get('/comments/{comment}/likes', [CommentLikeController::class, 'CommentLikers']);
+
+    Route::get('/artists/search', [ArtistController::class, 'search']);
 
 });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Http\Controllers\Api\AuthController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+
+Route::get('/user', function (Request $request) {
+    return $request->user();
+})->middleware('auth:sanctum');

--- a/tests/Feature/Api/CommentLikeTest.php
+++ b/tests/Feature/Api/CommentLikeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Diary;
+use App\Models\User;
+use App\Models\Artist;
+use App\Models\Like;
+
+// it('has api/commentlike page', function () {
+//     $response = $this->get('/api/commentlike');
+
+//     $response->assertStatus(200);
+// });
+
+beforeEach(function () {
+    $this->owner = User::factory()->create();
+    $this->user = User::factory()->create();
+    $this->artist = Artist::factory()->create();
+});
+
+it('【API】コメントにいいねが作成できる', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+    $comment = Comment::factory()->for($diary)->create();
+    $token = $this->user->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->postJson("/api/comments/{$comment->id}/like", ['user_id' => $this->user]);
+    $response->assertStatus(201);
+    $response->assertJson([
+        'ok' => true,
+        'liked' => true,
+    ]);
+    $response->assertJsonStructure(['ok', 'liked', 'count']);
+    $this->assertDatabaseHas('likes', [
+        'user_id' => $this->user->id,
+        'likeable_type' => Comment::class,
+        'likeable_id' => $comment->id,
+    ]);
+});
+
+it('コメントのいいねを取り消す', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+    $comment = Comment::factory()->for($diary)->create();
+    $token = $this->user->createToken('test_token')->plainTextToken;
+    Like::factory()->forComment($comment, $this->user)->create();
+
+    $response = $this->withToken($token)->delete("/api/comments/{$comment->id}/like");
+    $response->assertStatus(200);
+    $response->assertJson([
+        'ok' => true,
+        'liked' => false,
+    ]);
+    $response->assertJsonStructure(['ok', 'liked', 'count']);
+
+    $this->assertDatabaseMissing('likes', [
+        'user_id' => $this->user->id,
+        'likeable_type' => Comment::class,
+        'likeable_id' => $comment->id,
+    ]);
+});
+
+it('コメントのいいねユーザー一覧を表示できる', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+    $comment = Comment::factory()->for($diary)->for($this->user)->create();
+
+    $liker1 = User::factory()->create();
+    $liker2 = User::factory()->create();
+
+    Like::factory()->forComment($comment, $liker1)->create();
+    Like::factory()->forComment($comment, $liker2)->create();
+
+    $token = $this->user->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->get("/api/comments/{$comment->id}/likes");
+    
+    $response->assertStatus(200);
+    $response->assertJsonCount(2, 'likers.data');
+    expect($response->json('likers.data.*.name'))->toContain($liker1->name)->toContain($liker2->name);
+});

--- a/tests/Feature/Api/CommentTest.php
+++ b/tests/Feature/Api/CommentTest.php
@@ -1,0 +1,111 @@
+<?php
+use App\Models\User;
+use App\Models\Diary;
+use App\Models\Artist;
+use App\Models\Comment;
+
+
+beforeEach(function () {
+    $this->owner = User::factory()->create();
+    $this->user = User::factory()->create();
+    $this->artist = Artist::factory()->create();
+});
+
+it('【API】公開日記にコメント投稿できる', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+
+    $token = $this->user->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->postJson("/api/diaries/{$diary->id}/comments", ['body' => 'テストコメント']);
+
+    $response->assertStatus(201);
+    $this->assertDatabaseHas('comments', [
+        'user_id' => $this->user->id,
+        'diary_id' => $diary->id,
+        'body' => 'テストコメント',
+    ]);
+});
+
+it('【API】非公開日記に他人はコメントできない', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => false]);
+
+    $token = $this->user->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->postJson("/api/diaries/{$diary->id}/comments", ['body' => 'テストコメント']);
+    $response->assertStatus(403);
+    $this->assertDatabaseMissing('comments', [
+        'user_id' => $this->user->id,
+        'diary_id' => $diary->id,
+        'body' => 'テストコメント',
+    ]);
+});
+
+it('【API】本人のみが見られる日記詳細画面でコメント一覧が表示される', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+
+    $token = $this->owner->createToken('test_token')->plainTextToken;
+
+    $comment = Comment::factory()->for($diary)->for($this->user)->create();
+
+    $response = $this->withToken($token)->getJson("/api/diaries/{$diary->id}");
+    $response->assertStatus(200);
+    $response->assertJsonPath('comments.0.id', $comment->id);
+});
+
+it('【API】ログインユーザーが見られるみんなの日記の詳細画面でコメント一覧が表示される', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+    $viewer = User::factory()->create();
+    $token = $viewer->createToken('test_token')->plainTextToken;
+    $comment = Comment::factory()->for($diary)->for($this->user)->create();
+
+    $response = $this->withToken($token)->getJson("/api/public-diaries/{$diary->id}");
+    $response->assertStatus(200);
+    $response->assertJsonPath('comments.0.id', $comment->id);
+    $response->assertJsonPath('comments.0.user_id', $this->user->id);
+});
+
+it('【API】自分のコメントを削除できる', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+
+    $token = $this->user->createToken('test_token')->plainTextToken;
+    $comment = Comment::factory()->for($diary)->for($this->user)->create();
+    $isReply = $comment->parent_id !== null;
+
+    $response = $this->withToken($token)->deleteJson("/api/comments/{$comment->id}");
+    $response->assertStatus(200);
+    $response->assertJson(['isReply' => $isReply]);
+    $this->assertDatabaseMissing('comments', ['id' => $comment->id]);
+});
+
+it('【API】他人のコメントは削除できない', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+    $comment = Comment::factory()->for($diary)->for($this->user)->create();
+    $viewer = User::factory()->create();
+    $token = $viewer->createToken('test_token')->plainTextToken;
+    $response = $this->withToken($token)->deleteJson("/api/comments/{$comment->id}");
+    $response->assertStatus(403);
+    $this->assertDatabaseHas('comments', ['id' => $comment->id,]);
+});
+
+it('【API】コメントに返信投稿ができる', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+
+    $comment = Comment::factory()->for($diary)->for($this->user)->create();
+    $token = $this->owner->createToken('test_token')->plainTextToken;
+
+    $payload = [
+        'body' => 'テストリプライコメント',
+        'parent_id' => $comment->id,
+    ];
+    $response = $this->withToken($token)->postJson("/api/diaries/{$diary->id}/comments/reply", $payload);
+
+    $response->assertStatus(201);
+    $this->assertDatabaseHas('comments', [
+        'user_id' => $this->owner->id,
+        'diary_id' => $diary->id,
+        'body' => 'テストリプライコメント',
+        'parent_id' => $comment->id,
+        'depth' => 1,
+        'root_id' => $comment->id,
+    ]);
+});

--- a/tests/Feature/Api/DiaryLikeTest.php
+++ b/tests/Feature/Api/DiaryLikeTest.php
@@ -1,0 +1,73 @@
+<?php
+use App\Models\Artist;
+use App\Models\Diary;
+use App\Models\Like;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->artist = Artist::factory()->create();
+    $this->owner = User::factory()->create();
+    $this->user = User::factory()->create();
+});
+
+it('いいねが作成される', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+
+    $token = $this->user->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->postJson("/api/diaries/{$diary->id}/like", [
+        'user_id' => $this->user->id,
+    ]);
+    $response->assertStatus(201);
+    $response->assertJson([
+        'ok' => true,
+        'liked' => true,
+    ]);
+    $response->assertJsonStructure(['ok', 'liked', 'count']);
+    $this->assertDatabaseHas('likes', [
+        'user_id' => $this->user->id,
+        'likeable_type' => Diary::class,
+        'likeable_id' => $diary->id,
+    ]);
+});
+
+
+it('いいねを取り消す', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+    $token = $this->user->createToken('test_token')->plainTextToken;
+
+    Like::factory()->forDiary($diary, $this->user)->create([]);
+
+    $response = $this->withToken($token)->deleteJson("/api/diaries/{$diary->id}/like", ['user_id' => $this->user->id]);
+    $response->assertStatus(200);
+    $response->assertJson([
+        'ok' => true,
+        'liked' => false,
+    ]);
+    $response->assertJsonStructure(['ok', 'liked', 'count']);
+    $this->assertDatabaseMissing('likes', [
+        'user_id' => $this->user->id,
+        'likeable_type' => Diary::class,
+        'likeable_id' => $diary->id,
+    ]);
+});
+
+it('日記のいいねユーザー一覧を表示できる', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+
+    $liker1 = User::factory()->create();
+    $liker2 = User::factory()->create();
+
+    Like::factory()->forDiary($diary, $liker1)->create([]);
+    Like::factory()->forDiary($diary, $liker2)->create([]);
+
+    $token = $this->owner->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->get("/api/diaries/{$diary->id}/likes");
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(2, 'likers.data');
+    expect($response->json('likers.data.*.id'))
+        ->toContain($liker1->id)
+        ->toContain($liker2->id);
+});

--- a/tests/Feature/Api/DiaryTest.php
+++ b/tests/Feature/Api/DiaryTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Models\Artist;
+use App\Models\Diary;
+use App\Models\User;
+
+//  一覧表示のテスト
+it('【一覧表示テスト】自分の日記一覧が表示され、他人の日記は表示されない', function () {
+    $me = User::factory()->create();
+    $you = User::factory()->create();
+
+    $artist = Artist::factory()->create();
+
+    $myDiaries = Diary::factory()->for($me)->for($artist)->count(3)->create();
+    Diary::factory()->for($you)->for($artist)->count(2)->create();
+
+    $token = $me->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->getJson('/api/diaries');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(3, 'diaries.data');
+
+    // 返ってきた日記が全て自分のものであることを確認
+    $response->assertJsonPath(
+        'diaries.data.*.user_id',
+        $myDiaries->pluck('user_id')->all()
+    );
+});
+
+it('【作成テスト】日記が作成できる', function () {
+    $user = User::factory()->create();
+    $artist = Artist::factory()->create(['name' => 'テストアーティスト']);
+    $payload = [
+        'artist_id' => $artist->id,
+        'happened_on' => '2026-05-08',
+        'body' => '日記作成テスト',
+        'is_public' => true,
+    ];
+
+    $token = $user->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->postJson('/api/diaries', $payload);
+
+    $response->assertStatus(201);
+    $this->assertDatabaseHas('diaries', [
+        'user_id' => $user->id,
+        'artist_id' => $artist->id,
+        'happened_on' => '2026-05-08',
+        'body' => '日記作成テスト',
+        'is_public' => 1,
+    ]);
+});
+
+// 詳細表示のテスト
+it('【詳細表示テスト】自分の日記を取得できる', function () {
+    $me = User::factory()->create();
+    $artist = Artist::factory()->create();
+    $diary = Diary::factory()->for($me)->for($artist)->create();
+
+    $token = $me->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->getJson("/api/diaries/{$diary->id}");
+
+    $response->assertStatus(200);
+    $response->assertJsonPath('diary.id', $diary->id);
+});
+
+it('【詳細表示テスト】他人の日記は取得できない', function () {
+    $me = User::factory()->create();
+    $you = User::factory()->create();
+    $artist = Artist::factory()->create();
+    $diary = Diary::factory()->for($you)->for($artist)->create();
+
+    $token = $me->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->getJson("/api/diaries/{$diary->id}");
+
+    $response->assertStatus(403);
+});
+
+// 更新のテスト
+it('【更新テスト】自分の日記を更新できる', function () {
+    $me = User::factory()->create();
+    $artist = Artist::factory()->create();
+    $diary = Diary::factory()->for($me)->for($artist)->create();
+
+    $token = $me->createToken('test_token')->plainTextToken;
+
+    $payload = [
+        'happened_on' => '2026-01-01',
+        'artist_id' => $artist->id,
+        'body' => '更新後の本文',
+        'is_public' => true,
+    ];
+
+    $response = $this->withToken($token)->putJson("/api/diaries/{$diary->id}", $payload);
+
+    $response->assertStatus(200);
+    $this->assertDatabaseHas('diaries', [
+        'id' => $diary->id,
+        'body' => '更新後の本文',
+        'happened_on' => '2026-01-01',
+    ]);
+});
+
+it('【更新テスト】他人の日記は更新できない', function () {
+    $me = User::factory()->create();
+    $you = User::factory()->create();
+    $artist = Artist::factory()->create();
+    $diary = Diary::factory()->for($you)->for($artist)->create();
+
+    $token = $me->createToken('test_token')->plainTextToken;
+
+    $payload = [
+        'happened_on' => '2026-01-01',
+        'artist_id' => $artist->id,
+        'body' => '不正な更新',
+        'is_public' => false,
+    ];
+
+    $response = $this->withToken($token)->putJson("/api/diaries/{$diary->id}", $payload);
+
+    $response->assertStatus(403);
+});
+
+// 削除のテスト
+it('【削除テスト】自分の日記を削除できる', function () {
+    $me = User::factory()->create();
+    $artist = Artist::factory()->create();
+    $diary = Diary::factory()->for($me)->for($artist)->create();
+
+    $token = $me->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->deleteJson("/api/diaries/{$diary->id}");
+
+    $response->assertStatus(204);
+    $this->assertDatabaseMissing('diaries', ['id' => $diary->id]);
+});
+
+it('【削除テスト】他人の日記は削除できない', function () {
+    $me = User::factory()->create();
+    $you = User::factory()->create();
+    $artist = Artist::factory()->create();
+    $diary = Diary::factory()->for($you)->for($artist)->create();
+
+    $token = $me->createToken('test_token')->plainTextToken;
+
+    $response = $this->withToken($token)->deleteJson("/api/diaries/{$diary->id}");
+
+    $response->assertStatus(403);
+    $this->assertDatabaseHas('diaries', ['id' => $diary->id]);
+});

--- a/tests/Feature/CommentTest.php
+++ b/tests/Feature/CommentTest.php
@@ -41,7 +41,6 @@ it('非公開日記に他人はコメントできない', function() {
 
 it('本人のみが見られる日記詳細画面でコメント一覧が表示される', function() {
     $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
-    // $viewer = User::factory()->create();
 
     $comment = Comment::factory()->for($diary)->for($this->user)->create();
 
@@ -83,4 +82,27 @@ it('他人のコメントは削除できない', function() {
     $this->assertDatabaseHas('comments', ['id' => $comment->id,]);
 });
 
+it('コメントに返信投稿ができる', function () {
+    $diary = Diary::factory()->for($this->owner)->for($this->artist)->create(['is_public' => true]);
+
+    $comment = Comment::factory()->for($diary)->for($this->user)->create();
+
+    $payload = [
+        'body' => 'テストリプライコメント',
+        'parent_id' => $comment->id,
+    ];
+    $response = $this->actingAs($this->owner)->post(route('comments.reply', $diary), $payload);
+
+    $response->assertRedirect();
+    $response->assertSessionHas('status', '返信を投稿しました');
+
+    $this->assertDatabaseHas('comments', [
+        'user_id' => $this->owner->id,
+        'diary_id' => $diary->id,
+        'body' => 'テストリプライコメント',
+        'parent_id' => $comment->id,
+        'depth' => 1,
+        'root_id' => $comment->id,
+    ]);
+});
 

--- a/tests/Feature/DiaryTest.php
+++ b/tests/Feature/DiaryTest.php
@@ -361,6 +361,7 @@ it('他人は更新できない（policy: update）', function(){
   $diary = Diary::factory()->for($owner)->for($artist)->create();
 
   $response = $this->actingAs($other)->put(route('diaries.update', $diary), [
+    'artist_id' => $artist->id,
     'happened_on' => '2025-01-25',
     'body' => '更新できない',
     'is_public' => false,


### PR DESCRIPTION
## Summary
- `feature/api-migration` ブランチで進めてきたLaravel REST API化の作業をdevelopに統合し、mainへ反映する
- Next.jsフロントエンドとの通信を前提としたAPIエンドポイント（日記、コメント、いいね、フォロー、ブロック、通知、AI日記提案、Artist管理など）を追加
- Sanctumによるトークン認証（Bearer）を導入し、CORS設定を新規追加

## Note
- `config/cors.php` の `allowed_origins` が `http://localhost:3000` にハードコードされています。本番のNext.jsフロントエンドのドメインが含まれていないため、マージ後は本番ドメインを追加する対応が別途必要です。
- `.github/workflows/deploy.yml` によりmainへのpushで本番へ自動デプロイ（`migrate --force`含む）されます。

## Test plan
- [ ] マージ後、本番相当環境でNext.jsフロントエンドからのAPI疎通を確認
- [ ] `config/cors.php` に本番ドメインを追加
- [ ] マイグレーション（Sanctumトークンテーブル、Artist関連）が本番DBに問題なく適用されることを確認